### PR TITLE
Add UTF-8 support to VMD

### DIFF
--- a/mmd_tools/core/vmd/__init__.py
+++ b/mmd_tools/core/vmd/__init__.py
@@ -13,10 +13,14 @@ class InvalidFileError(Exception):
 
 ## vmd仕様の文字列をstringに変換
 def _toShiftJisString(byteString):
+    name = byteString.split(b"\x00")[0]
     try:
-        name = byteString.split(b"\x00")[0].decode("shift_jis")
-    except UnicodeDecodeError:
-        name = byteString.split(b"\x00")[0].decode("utf-8")
+        name = name.decode("shift_jis")
+    except UnicodeDecodeError as error:
+        if error.args[0].endswith("incomplete multibyte sequence"):
+            name = name.decode("shift_jis", errors="replace")
+        else:
+            name = byteString.split(b"\x00")[0].decode("utf-8", errors="replace")
     return name
 
 

--- a/mmd_tools/core/vmd/__init__.py
+++ b/mmd_tools/core/vmd/__init__.py
@@ -24,6 +24,7 @@ def _toShiftJisBytes(string):
     try:
         name = string.encode("shift_jis")
     except UnicodeEncodeError:
+        logging.info("Encode bone name '%s' to utf-8", string)
         name = string.encode("utf-8")
     return name
 


### PR DESCRIPTION
MMDtools directly discards unsupported characters when exporting VMDs, but it's feasible to keep it and it doesn't affect MMD loading in tests. Due to the size of UTF-8, longer names can be saved using GBK.