### PR TITLE
Fix vmd importer when a vmd needs ik toggle

### DIFF
--- a/mmd_tools/__init__.py
+++ b/mmd_tools/__init__.py
@@ -3,7 +3,7 @@
 bl_info = {
     "name": "mmd_tools",
     "author": "sugiany",
-    "version": (2, 10, 0),
+    "version": (2, 10, 1),
     "blender": (2, 93, 0),
     "location": "View3D > Sidebar > MMD Tools Panel",
     "description": "Utility tools for MMD model editing. (UuuNyaa's forked version)",

--- a/mmd_tools/__init__.py
+++ b/mmd_tools/__init__.py
@@ -3,7 +3,7 @@
 bl_info = {
     "name": "mmd_tools",
     "author": "sugiany",
-    "version": (2, 10, 1),
+    "version": (2, 10, 2),
     "blender": (2, 93, 0),
     "location": "View3D > Sidebar > MMD Tools Panel",
     "description": "Utility tools for MMD model editing. (UuuNyaa's forked version)",

--- a/mmd_tools/__init__.py
+++ b/mmd_tools/__init__.py
@@ -3,7 +3,7 @@
 bl_info = {
     "name": "mmd_tools",
     "author": "sugiany",
-    "version": (2, 10, 2),
+    "version": (2, 10, 3),
     "blender": (2, 93, 0),
     "location": "View3D > Sidebar > MMD Tools Panel",
     "description": "Utility tools for MMD model editing. (UuuNyaa's forked version)",

--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -261,22 +261,18 @@ class FnModel:
                     continue
                 mmd_bone.additional_transform_bone_id = new_bone_id
         
-        # Change Child Bone IDs temporarily to large numbers to completely avoid Bone ID conflict.
-        tmp_bone_id = 1000000000
-        for child_root_object in child_root_objects:
-            child_armature_object = FnModel.find_armature(child_root_object)
-            child_pose_bones = child_armature_object.pose.bones
-            child_bone_morphs = child_root_object.mmd_root.bone_morphs
-
-            for pose_bone in child_pose_bones:
-                if pose_bone.is_mmd_shadow_bone:
-                    continue
-                if pose_bone.mmd_bone.bone_id != -1:
-                    tmp_bone_id += 1
-                    _change_bone_id(pose_bone, tmp_bone_id, child_bone_morphs, child_pose_bones)
-        
-        # Reorder Child Bone IDs.
-        max_bone_id = max((b.mmd_bone.bone_id for b in parent_armature_object.pose.bones if not b.is_mmd_shadow_bone), default=-1)
+        max_bone_id = max(
+            (
+                b.mmd_bone.bone_id
+                for o in itertools.chain(
+                    child_root_objects,
+                    [parent_root_object],
+                )
+                for b in FnModel.find_armature(o).pose.bones
+                if not b.is_mmd_shadow_bone
+            ),
+            default=-1,
+        )
         
         child_root_object: bpy.types.Object
         for child_root_object in child_root_objects:

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -471,7 +471,7 @@ class VMDImporter:
                     bone = pose_bones.get(ikName, None)
                     if not bone:
                         continue
-
+                    bone.mmd_ik_toggle = enable
                     self.__keyframe_insert(action.fcurves, f'pose.bones["{bone.name}"].mmd_ik_toggle', frame, enable)
 
         self.__assign_action(armObj, action)

--- a/mmd_tools/operators/addon_updater.py
+++ b/mmd_tools/operators/addon_updater.py
@@ -20,7 +20,7 @@
 
 # This file is copied from
 #   https://github.com/nutti/Screencast-Keys/blob/a16f6c7dd697f6ec7bced5811db4a8144514d320/src/screencast_keys/utils/addon_updater.py
-
+# fmt: off
 
 import datetime
 import json
@@ -176,6 +176,7 @@ class AddonUpdaterConfig:
         # If you specify (-1, -1), ignore versions less than current add-on
         # version specified in bl_info.
         self.min_release_version = (-1, -1)
+        self.max_release_version = (+999, +999)
 
         # Target add-on path
         # {"branch/tag": "add-on path"}
@@ -268,8 +269,7 @@ class AddonUpdaterManager:
             releases = _get_all_releases_data(self.__config.owner,
                                               self.__config.repository)
             for r in releases:
-                if _compare_version(_parse_release_version(r["tag_name"]),
-                                    self.__config.min_release_version) > 0:
+                if _compare_version(_parse_release_version(r["tag_name"]), self.__config.min_release_version) > 0 and _compare_version(_parse_release_version(r["tag_name"]), self.__config.max_release_version) < 0:
                     info = UpdateCandidateInfo()
                     info.name = r["tag_name"]
                     info.url = r["assets"][0]["browser_download_url"]
@@ -377,25 +377,27 @@ class AddonUpdaterManager:
     def updated(self):
         return self.__updated
 
+# fmt: on
 
 
 class CheckAddonUpdate(bpy.types.Operator):
     bl_idname = "mmd_tools.check_addon_update"
     bl_label = "Check Update"
     bl_description = "Check Add-on Update"
-    bl_options = {'INTERNAL'}
+    bl_options = {"INTERNAL"}
 
     def execute(self, context):
         updater = AddonUpdaterManager.get_instance()
         updater.check_update_candidate()
 
-        return {'FINISHED'}
+        return {"FINISHED"}
+
 
 class UpdateAddon(bpy.types.Operator):
     bl_idname = "mmd_tools.update_addon"
     bl_label = "Update"
     bl_description = "Update Add-on"
-    bl_options = {'INTERNAL'}
+    bl_options = {"INTERNAL"}
 
     branch_name: bpy.props.StringProperty(
         name="Branch Name",
@@ -407,17 +409,19 @@ class UpdateAddon(bpy.types.Operator):
         updater = AddonUpdaterManager.get_instance()
         updater.update(self.branch_name)
 
-        return {'FINISHED'}
+        return {"FINISHED"}
+
 
 def register_updater(bl_info, init_py_file):
     config = AddonUpdaterConfig()
-    config.owner = 'UuuNyaa'
-    config.repository = 'blender_mmd_tools'
+    config.owner = "UuuNyaa"
+    config.repository = "blender_mmd_tools"
     config.current_addon_path = os.path.dirname(os.path.realpath(init_py_file))
-    config.branches = ['main']
+    config.branches = ["main"]
     config.addon_directory = os.path.dirname(config.current_addon_path)
     config.min_release_version = (1, 0, 0)
-    config.default_target_addon_path = 'mmd_tools'
+    config.max_release_version = (4, 0, 0)
+    config.default_target_addon_path = "mmd_tools"
     config.target_addon_path = {}
     updater = AddonUpdaterManager.get_instance()
     updater.init(bl_info, config)


### PR DESCRIPTION
v2.2.3 の mmd_tools/core/vmd/importer.py の438行目の削除によって、vmdをインポート時にIKをオフにするタイプのvmdでもIKがオフにならない問題が発生しています。

https://github.com/UuuNyaa/blender_mmd_tools/commit/ad38eecfcf6b413f5bdb6a620ed972eed5227bfc#diff-c51bd41b801e84de74a398107f070f78aebf7792e5392e8340b121157930eedfL438

![image](https://github.com/user-attachments/assets/d4f0c96e-da68-4d46-b7bc-1d9d906ffe61)

bone.mmd_ik_toggle = enable を復活させることにより問題を修正できることがわかったため、プルリクエストを作成しました。
ただし、その他の影響範囲などについては調査できていないため、（1行だけの変更ではありますが）新たなバグの原因となってしまわないか少し心配しています。

以下、補足情報です。

現象の再現に使用したblenderバージョン：3.6.19
現象の再現に使用したvmdモーション：Marine Bloomin’（規約的に問題なさそうなので添付します：[Marine_Bloomin'_dance_ApMiku.zip](https://github.com/user-attachments/files/18321000/Marine_Bloomin._dance_ApMiku.zip)）

修正前のスクリーンショット：
![before-fix](https://github.com/user-attachments/assets/0a2fd46f-a97a-4a21-babd-1d6ab23f72ae)

修正後のスクリーンショット：
![after-fix](https://github.com/user-attachments/assets/78b9662e-1309-46e9-a801-f374b190a91e)

discordに同内容を報告済です。（ https://discord.com/channels/854835858837340211/902023888937058374/1325647169939705887 ）。
よろしくお願いいたします。

追伸：いつも使用させていただいています。長期にわたる継続的なメンテナンス、ありがとうございます。