### PR TITLE
Add convertToMMDShader for v3

### DIFF
--- a/mmd_tools/cycles_converter.py
+++ b/mmd_tools/cycles_converter.py
@@ -2,6 +2,7 @@
 import bpy
 import logging
 from mmd_tools.core.shader import _NodeGroupUtils
+from mmd_tools.core.material import _FnMaterialCycles
 
 def __switchToCyclesRenderEngine():
     if bpy.context.scene.render.engine != 'CYCLES':
@@ -110,6 +111,15 @@ def convertToBlenderShader(obj, use_principled=False, clean_nodes=False, subsurf
             __convertToPrincipledBsdf(i.material, subsurface)
         if clean_nodes:
             __cleanNodeTree(i.material)
+
+def convertToMMDShader(obj):
+    """BSDF -> MMDShaderDev conversion."""
+    for i in obj.material_slots:
+        if not i.material:
+            continue
+        if not i.material.use_nodes:
+            i.material.use_nodes = True
+        _FnMaterialCycles.convert_to_mmd_material(i.material)
 
 def __convertToMMDBasicShader(material):
     mmd_basic_shader_grp = create_MMDBasicShader()

--- a/mmd_tools/operators/material.py
+++ b/mmd_tools/operators/material.py
@@ -88,6 +88,23 @@ class ConvertMaterials(Operator):
             cycles_converter.convertToBlenderShader(obj, use_principled=self.use_principled, clean_nodes=self.clean_nodes, subsurface=self.subsurface)
         return {'FINISHED'}
 
+class ConvertBSDFMaterials(Operator):
+    bl_idname = 'mmd_tools.convert_bsdf_materials'
+    bl_label = 'Convert Blender Materials'
+    bl_description = 'Convert materials of selected objects.'
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        return next((x for x in context.selected_objects if x.type == 'MESH'), None)
+
+    def execute(self, context):
+        for obj in context.selected_objects:
+            if obj.type != 'MESH':
+                continue
+            cycles_converter.convertToMMDShader(obj)
+        return {'FINISHED'}
+
 class _OpenTextureBase(object):
     """ Create a texture for mmd model material.
     """

--- a/mmd_tools/panels/sidebar.py
+++ b/mmd_tools/panels/sidebar.py
@@ -235,6 +235,7 @@ class MMDToolsModelSetupPanel(bpy.types.Panel):
         row.operator('mmd_tools.edge_preview_setup', text='', icon='TRASH').action = 'CLEAN'
         row = grid.row(align=True)
         row.operator('mmd_tools.convert_materials', text='Convert to Blender', icon='BLENDER')
+        row.operator('mmd_tools.convert_bsdf_materials', text='Convert to MMD', icon='MATSPHERE')
 
     def draw_misc(self, context, mmd_root_object):
         col = self.layout.column(align=True)


### PR DESCRIPTION
I implemented requested feature #190 (BSDF to MMDShaderDev) for blender-v3.

It adds new button next to "convert to blender" button. It uses existing functions from "Convert model", with a few improvements like diffuse/ambient color conversion.

<img width="259" alt="Screenshot_2025-03-06_at_13 00 22" src="https://github.com/user-attachments/assets/7d5d7f6c-ffd7-4d7b-977e-e9c9356bb0a4" />
