### PR TITLE
Refine release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,16 @@
 on:
   push:
-    branches:
-      - "!*"
     tags:
-      - "v*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 name: Release
 
 jobs:
-  build:
+  release:
+    # Note: `github.event.base_ref` is equal to `refs/heads/main` when the workflow is triggered
+    # by a branch, or a lightweight tag (_not_ an annotated tag), placed on the last commit of the `main` branch
+    if: github.event.base_ref == 'refs/heads/main'
+
     runs-on: ubuntu-latest
 
     steps:
@@ -21,7 +23,12 @@ jobs:
             ["v2"]="bl3.6"
             ["v4"]="bl4.2"
           )
-          echo "zip_filename=mmd_tools-${GITHUB_REF_NAME}-${tag_prefix_to_blender_version[${GITHUB_REF_NAME%%.*}]}.zip" >> $GITHUB_ENV
+          blender_version=${tag_prefix_to_blender_version[${GITHUB_REF_NAME%%.*}]}
+          if [ -z "$blender_version" ]; then
+            echo "Error: No Blender version mapping found for tag ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+          echo "zip_filename=mmd_tools-${GITHUB_REF_NAME}-${blender_version}.zip" >> $GITHUB_ENV
 
       - name: Copy LICENSE file
         run: cp -p LICENSE mmd_tools/

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,86 +1,84 @@
 # MMD Tools Developer Guide
 
-This guide is meant to help new and experienced contributors understand MMD Tools’ goals, structure, and recommended practices. Please read it carefully before submitting ideas or pull requests.
+This guide helps both new and experienced contributors understand MMD Tools’ goals, structure, and recommended practices.
+Please read it carefully before submitting ideas or pull requests.
 
 ## Project Scope
 
 ### Core Principles
-- Focus on MikuMikuDance (MMD) compatibility
-- Provide a seamless and user-friendly workflow between Blender and MMD
-- Preserve format integrity for models, motions, and poses
-- For functionality beyond MMD Tools’ scope, create separate add-ons instead of modifying MMD Tools
+- **MMD Compatibility**: MMD Tools preserves official MikuMikuDance (MMD) file formats for models, motions, and poses
+- **User-Friendly Workflow**: By focusing on MMD-compatible features, MMD Tools provides a straightforward, efficient experience for MMD users within Blender
+- **Non-Breaking Enhancements**: Only improvements and tools that do not break the MMD format integrity are added
 
 ### Supported Features
-1. **Import/Export** - Complete support for MMD file formats
-2. **Editing** - Tools to modify MMD assets within Blender
-3. **Compatibility** - Support for all standard MMD features
-4. **Verification** - Preview and validation features (e.g. Physics) for MMD compatibility
+1. **Import/Export** - Read and write MMD formats without altering the MMD file formats
+2. **Editing** - Support editing and modifying MMD data in Blender while preserving MMD compatibility
+3. **Verification** - Preview and confirm MMD-compliant physics, motions, and other features directly in Blender
 
 ### Out of Scope
-1. **Extended Functionality** - Features beyond MMD capabilities
-2. **Format Modifications** - Changes that break MMD compatibility
-3. **Non-Standard Extensions** - Additions not supported by MMD
+1. **MMD Format Changes** - Any modification that breaks official MMD specifications or compatibility
+2. **Extended Functionality** - Features that significantly exceed MMD’s scope—such as advanced rigging or shader systems specialized for high-end movie production—should be developed as separate add-ons
+3. **Third-Party Incorporations** - Support for non-MMD workflows or custom file formats
 
 ## Development Environment
 
 ### Prerequisites
-- Ensure Blender is installed and matches the target branch version
+- Ensure you have a matching version of Blender for the target development branch
 - Use the correct Python version for your Blender release
-- Ensure GitHub access to the [repository](https://github.com/MMD-Blender/blender_mmd_tools)
+- Get GitHub access to the [MMD Tools repository](https://github.com/MMD-Blender/blender_mmd_tools)
 
-| Blender Version | MMD Tools Version | Python Version | Branch      |
-|-----------------|-------------------|---------------:|-------------|
-| Blender 4.2 LTS | MMD Tools v4.x    |           3.11 | [main](https://github.com/MMD-Blender/blender_mmd_tools) |
+| Blender Version | MMD Tools Version | Python Version | Branch                                                                         |
+|-----------------|-------------------|---------------:|--------------------------------------------------------------------------------|
+| Blender 4.2 LTS | MMD Tools v4.x    |           3.11 | [main](https://github.com/MMD-Blender/blender_mmd_tools)                       |
 | Blender 3.6 LTS | MMD Tools v2.x    |           3.10 | [blender-v3](https://github.com/MMD-Blender/blender_mmd_tools/tree/blender-v3) |
 
 ### Recommendations
 - Use a dedicated Python virtual environment for development
 - Use [Ruff](https://github.com/astral-sh/ruff) for linting and formatting
-- Use [fake-bpy-module](https://github.com/nutti/fake-bpy-module) for the code completion and type checking in IDEs
+- Use [fake-bpy-module](https://github.com/nutti/fake-bpy-module) for code completion and type checking in IDEs
 
 ## Project Structure
 ```
 blender_mmd_tools/
-├── mmd_tools/            # Main module directory
-│   ├── core/             # Core functionality 
-│   ├── operators/        # Blender operators
-│   ├── panels/           # Blender UI panels
-│   ├── properties/       # Blender Property definitions
-│   ├── externals/        # Dependent 3rd-party modules with README.txt
-│   └── typings/          # Python Type Hints (.pyi)
-└── docs/                 # Documentation (not yet)
+├── mmd_tools/         # Main module directory
+│   ├── core/          # Core functionality
+│   ├── operators/     # Blender operators
+│   ├── panels/        # Blender UI panels
+│   ├── properties/    # Blender Property definitions
+│   ├── externals/     # Dependent 3rd-party modules with README.txt
+│   └── typings/       # Python Type Hints (.pyi)
+└── docs/              # Documentation (not yet)
 ```
 
 ## Coding Standards
 
 ### Python Style
-- Use [Ruff’s default style](https://docs.astral.sh/ruff/formatter/#philosophy) configuration for linting and formatting
+- Use [Ruff’s default style](https://docs.astral.sh/ruff/formatter/#philosophy) for linting and formatting
 - Keep line length under 256 characters (`--line-length=256`)
-- Continue using 4 spaces for indentation (not tabs)
-- Add the following at the top of each Python file:
-    ```
-    # -*- coding: utf-8 -*-
-    # Copyright {year} MMD Tools authors
-    # This file is part of MMD Tools.
-   ```
+- Indent with 4 spaces (no tabs)
+- Add the following comment block at the top of each Python file:
+  ```
+  # -*- coding: utf-8 -*-
+  # Copyright {year} MMD Tools authors
+  # This file is part of MMD Tools.
+  ```
 
 ### Naming Conventions
-- Follow Ruff’s recommended naming style for classes, functions, variables, and constants
+- Follow Ruff’s conventions for classes, functions, variables, and constants
 
 ### Comments and Documentation
-- Write docstrings for all functions, classes, and modules
-- Write clear comments for complex logic
-- Maintain up-to-date docstrings and documentation
+- Write docstrings for public functions, classes, and modules
+- Provide clear comments for complex logic
+- Keep docstrings and documentation updated as the code evolves
 
-
-## Git Workflow (GitHub flow)
-We adopt [GitHub flow](https://docs.github.com/en/get-started/using-github/github-flow) to keep the development process simple and straightforward.
+## Git Workflow (GitHub Flow)
+We adopt [GitHub flow](https://docs.github.com/en/get-started/using-github/github-flow) for a simple, flexible development process:
 
 1. Create a branch from `main`:
    ```
    git checkout -b feature/your-feature
    ```
-2. Make your changes with small, focused commits
+2. Make your changes in small, focused commits
 3. Write meaningful commit messages:
    ```
    [Component] Short description
@@ -88,24 +86,20 @@ We adopt [GitHub flow](https://docs.github.com/en/get-started/using-github/githu
    ```
 4. Push your branch to your fork
 5. Open a pull request against `main`
-6. Merge your pull request once approved
-
+6. Merge your pull request once it’s approved
 
 ## Release Process
+Currently, only @UuuNyaa has permission to perform release tasks:
 
-Currently, only @UuuNyaa has permission to perform release tasks.
-
-1. Add a version tag (`vMAJOR.MINOR.PATCH`) to the commit targeted for release in `main` branch
-2. When you push the version tag, GitHub Actions automatically builds artifacts and creates a GitHub Release Draft
-3. Manually finish the GitHub Release Draft and publish it
+1. Tag the commit in `main` with the version number (`vMAJOR.MINOR.PATCH`)
+2. Pushing the tag triggers a GitHub Action that builds artifacts and creates a draft release
+3. Manually finalize and publish the GitHub Release draft
 4. Manually upload the artifacts to [Blender Extensions](https://extensions.blender.org/add-ons/mmd-tools/)
 
 ## Getting Help
-
 If you need help with development:
-
 - Ask questions in the [MMD & Blender Discord Server](https://discord.gg/zRgUkuaPWw) `#addon-development` channel
-- Open an issue for discussing implementation details
-- Check existing code for patterns and approaches
+- Open an issue to discuss implementation details
+- Refer to existing code for patterns and approaches
 
 We appreciate your contributions and look forward to working together to improve MMD Tools!


### PR DESCRIPTION
Testing the `main` branch protection workflow
![image](https://github.com/user-attachments/assets/d6999f90-7ef9-4731-a9ab-a77fc2829e2a)

## Changes
- Change the tag pattern from any `v*` to a specific format requiring semantic versioning (`v1.2.3`)
- Add a condition that only runs the workflow when tags are created on the `main` branch
- Add validation to check if there's a Blender version mapping for the tag prefix if no mapping exists, the workflow fails with a clear error message
- Update DEVELOPER_GUIDE.md
  - Streamlined the text for clarity, reduced and reorganized features in "Supported Features", focused more on MMD integrity.