### PR TITLE
[Bone] Fix Local Axes mapping between Blender (Z-up) and MMD (Y-up)

### DIFF
--- a/mmd_tools/core/bone.py
+++ b/mmd_tools/core/bone.py
@@ -289,8 +289,10 @@ class FnBone:
             mmd_bone.enabled_local_axes = enable
             if enable:
                 axes = b.bone.matrix_local.to_3x3().transposed()
-                mmd_bone.local_axis_x = axes[0].xzy
-                mmd_bone.local_axis_z = axes[2].xzy
+
+                # Blender is Z up. MMD is Y up.
+                mmd_bone.local_axis_x = axes[2].xzy
+                mmd_bone.local_axis_z = axes[1].xzy
 
     @staticmethod
     def apply_bone_local_axes(armature_object: bpy.types.Object):


### PR DESCRIPTION
Fix the incorrect local axes mapping when using the "Load" button in Local Axes Setup.

The bone local axes were incorrectly transferred between Blender and MMD coordinate systems, causing orientation issues when exported models were used in MMD.

This resolves the local axes inconsistency reported in issue #149.