### PR TITLE
[Core] Preserve original PMX Display Connection (Bone Target)

### DIFF
--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -224,24 +224,24 @@ class FnModel:
         Changes bone ID and updates all references without validating if new_bone_id is already in use.
         If new_bone_id is already in use, it may cause conflicts and corrupt existing bone references.
         """
-        # Store original bone_id and change it
+        # Store the original bone_id and change it
         bone_id = bone.mmd_bone.bone_id
         bone.mmd_bone.bone_id = new_bone_id
 
-        # Update bone_id references in all bone morphs
+        # Update all bone_id references in bone morphs
         for bone_morph in bone_morphs:
             for data in bone_morph.data:
                 if data.bone_id == bone_id:
                     data.bone_id = new_bone_id
 
-        # Update additional transform references in all pose bones
+        # Update all additional_transform_bone_id references in pose bones
         for pose_bone in pose_bones:
             if not hasattr(pose_bone, 'is_mmd_shadow_bone') or not pose_bone.is_mmd_shadow_bone:
                 mmd_bone = pose_bone.mmd_bone
                 if mmd_bone.additional_transform_bone_id == bone_id:
                     mmd_bone.additional_transform_bone_id = new_bone_id
 
-        # Update display connection references in all pose bones
+        # Update all display_connection_bone_id references in pose bones
         for pose_bone in pose_bones:
             if not hasattr(pose_bone, 'is_mmd_shadow_bone') or not pose_bone.is_mmd_shadow_bone:
                 mmd_bone = pose_bone.mmd_bone

--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -234,12 +234,19 @@ class FnModel:
                 if data.bone_id == bone_id:
                     data.bone_id = new_bone_id
 
-        # Update transform references in all pose bones
+        # Update additional transform references in all pose bones
         for pose_bone in pose_bones:
             if not hasattr(pose_bone, 'is_mmd_shadow_bone') or not pose_bone.is_mmd_shadow_bone:
                 mmd_bone = pose_bone.mmd_bone
                 if mmd_bone.additional_transform_bone_id == bone_id:
                     mmd_bone.additional_transform_bone_id = new_bone_id
+
+        # Update display connection references in all pose bones
+        for pose_bone in pose_bones:
+            if not hasattr(pose_bone, 'is_mmd_shadow_bone') or not pose_bone.is_mmd_shadow_bone:
+                mmd_bone = pose_bone.mmd_bone
+                if mmd_bone.display_connection_bone_id == bone_id:
+                    mmd_bone.display_connection_bone_id = new_bone_id
 
     @staticmethod
     def safe_change_bone_id(bone: bpy.types.PoseBone, new_bone_id: int, bone_morphs, pose_bones):

--- a/mmd_tools/core/pmd/importer.py
+++ b/mmd_tools/core/pmd/importer.py
@@ -95,12 +95,10 @@ def import_pmd_to_pmx(filepath):
         pmx_bone.name_e = bone.name_e
         pmx_bone.location = bone.position
         pmx_bone.parent = bone.parent
-        if bone.type != 9 and bone.type != 8:
-            pmx_bone.displayConnection = bone.tail_bone
+        if bone.type != 9 and bone.type != 8 and bone.tail_bone > 0:
+            pmx_bone.displayConnection = bone.tail_bone  # Corresponds to 'BONE' type
         else:
-            pmx_bone.displayConnection = -1
-        if pmx_bone.displayConnection <= 0:
-            pmx_bone.displayConnection = (0.0, 0.0, 0.0)
+            pmx_bone.displayConnection = -1  # Corresponds to 'NONE' type
         pmx_bone.isIK = False
         if bone.type == 0:
             pmx_bone.isMovable = False

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -1218,6 +1218,8 @@ class __PmxExporter:
         rigids = sorted(args.get("rigid_bodies", []), key=lambda x: x.name)
         joints = sorted(args.get("joints", []), key=lambda x: x.name)
 
+        bpy.ops.mmd_tools.fix_bone_order()
+
         self.__scale = args.get("scale", 1.0)
         self.__disable_specular = args.get("disable_specular", False)
         sort_vertices = args.get("sort_vertices", "NONE")

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -272,20 +272,6 @@ class PMXImporter:
                 elif FnBone.has_auto_local_axis(m_bone.name):
                     FnBone.update_auto_bone_roll(b_bone)
 
-            for b_bone, m_bone in zip(editBoneTable, pmx_bones):
-                if isinstance(m_bone.displayConnection, int) and m_bone.displayConnection >= 0:
-                    t = editBoneTable[m_bone.displayConnection]
-                    if t.parent is None or t.parent != b_bone:
-                        continue
-                    if pmx_bones[m_bone.displayConnection].isMovable:
-                        continue
-                    if (b_bone.tail - t.head).length > 1e-4:
-                        continue
-                    if not m_bone.isMovable:
-                        continue
-                    logging.warning(" * connected: %s (%d)-> %s", b_bone.name, len(b_bone.children), t.name)
-                    t.use_connect = True
-
         return nameTable, specialTipBones
 
     def __sortPoseBonesByBoneIndex(self, pose_bones: List[bpy.types.PoseBone], bone_names):
@@ -432,10 +418,23 @@ class PMXImporter:
             mmd_bone.transform_after_dynamics = pmx_bone.transAfterPhis
             mmd_bone.bone_id = i
 
-            if pmx_bone.displayConnection == -1 or pmx_bone.displayConnection == (0.0, 0.0, 0.0):
+            # set display_connection properties
+            if pmx_bone.displayConnection == -1:
+                mmd_bone.display_connection_type = 'NONE'
                 mmd_bone.is_tip = True
-            elif b_bone.name in specialTipBones:
+            elif pmx_bone.displayConnection == (0.0, 0.0, 0.0):
+                mmd_bone.display_connection_type = 'NONE'
                 mmd_bone.is_tip = True
+            elif isinstance(pmx_bone.displayConnection, int):
+                mmd_bone.display_connection_type = 'BONE'
+                mmd_bone.display_connection_bone_id = pmx_bone.displayConnection
+                if b_bone.name in specialTipBones:
+                    mmd_bone.is_tip = True
+            else:  # vector offset
+                mmd_bone.display_connection_type = 'OFFSET'
+                mmd_bone.display_connection_offset = pmx_bone.displayConnection
+                if b_bone.name in specialTipBones:
+                    mmd_bone.is_tip = True
 
             b_bone.bone.hide = not pmx_bone.visible  # or mmd_bone.is_tip
 

--- a/mmd_tools/panels/prop_bone.py
+++ b/mmd_tools/panels/prop_bone.py
@@ -90,3 +90,12 @@ class MMDBonePanel(bpy.types.Panel):
             row.label(icon="ERROR")
         c.prop_search(mmd_bone, "additional_transform_bone", pose_bone.id_data.pose, "bones", icon="BONE_DATA", text="")
         c.prop(mmd_bone, "additional_transform_influence", text="Influence", slider=True)
+
+        c = layout.column(align=True)
+        c.label(text="Display Connection (Bone Target):")
+        c.row().prop(mmd_bone, "display_connection_type", text="Type")
+
+        if mmd_bone.display_connection_type == 'BONE':
+            c.prop_search(mmd_bone, "display_connection_bone", pose_bone.id_data.pose, "bones", icon="BONE_DATA", text="Target Bone")
+        elif mmd_bone.display_connection_type == 'OFFSET':
+            c.prop(mmd_bone, "display_connection_offset", text="")

--- a/mmd_tools/properties/pose_bone.py
+++ b/mmd_tools/properties/pose_bone.py
@@ -11,6 +11,7 @@ from . import patch_library_overridable
 
 def _mmd_bone_update_additional_transform(prop: "MMDBone", context: bpy.types.Context):
     prop["is_additional_transform_dirty"] = True
+    # Apply additional transformation (Assembly -> Bone button) (Very Slow)
     p_bone = context.active_pose_bone
     if p_bone and p_bone.mmd_bone.as_pointer() == prop.as_pointer():
         FnBone.apply_additional_transformation(prop.id_data)

--- a/mmd_tools/properties/pose_bone.py
+++ b/mmd_tools/properties/pose_bone.py
@@ -46,6 +46,26 @@ def _mmd_bone_set_additional_transform_bone(prop: "MMDBone", value: str):
     prop["additional_transform_bone_id"] = FnBone.get_or_assign_bone_id(pose_bone)
 
 
+def _mmd_bone_get_display_connection_bone(prop: "MMDBone"):
+    arm = prop.id_data
+    bone_id = prop.get("display_connection_bone_id", -1)
+    if bone_id < 0:
+        return ""
+    pose_bone = FnBone.find_pose_bone_by_bone_id(arm, bone_id)
+    if pose_bone is None:
+        return ""
+    return pose_bone.name
+
+
+def _mmd_bone_set_display_connection_bone(prop: "MMDBone", value: str):
+    arm = prop.id_data
+    if value not in arm.pose.bones.keys():
+        prop["display_connection_bone_id"] = -1
+        return
+    pose_bone = arm.pose.bones[value]
+    prop["display_connection_bone_id"] = FnBone.get_or_assign_bone_id(pose_bone)
+
+
 class MMDBone(bpy.types.PropertyGroup):
     name_j: bpy.props.StringProperty(
         name="Name",
@@ -181,6 +201,39 @@ class MMDBone(bpy.types.PropertyGroup):
     )
 
     is_additional_transform_dirty: bpy.props.BoolProperty(name="", default=True)
+
+    display_connection_bone: bpy.props.StringProperty(
+        name="Display Connection Bone",
+        description="Target bone for display connection",
+        set=_mmd_bone_set_display_connection_bone,
+        get=_mmd_bone_get_display_connection_bone,
+    )
+
+    display_connection_bone_id: bpy.props.IntProperty(
+        name="Display Connection Bone ID",
+        description="Bone ID for display connection (PMX displayConnection)",
+        default=-1,
+    )
+
+    display_connection_type: bpy.props.EnumProperty(
+        name="Display Connection Type",
+        description="Type of display connection",
+        items=[
+            ('BONE', "Bone", "Connected to a bone"),
+            ('OFFSET', "Offset", "Connected to an offset position"),
+            ('NONE', "None", "No connection")
+        ],
+        default='NONE',
+    )
+
+    display_connection_offset: bpy.props.FloatVectorProperty(
+        name="Display Connection Offset",
+        description="Offset vector for display connection",
+        subtype="XYZ",
+        size=3,
+        precision=3,
+        default=(0, 0, 0),
+    )
 
     def is_id_unique(self):
         return self.bone_id < 0 or not next((b for b in self.id_data.pose.bones if b.mmd_bone != self and b.mmd_bone.bone_id == self.bone_id), None)

--- a/mmd_tools/typings/mmd_tools/properties/pose_bone.pyi
+++ b/mmd_tools/typings/mmd_tools/properties/pose_bone.pyi
@@ -24,3 +24,7 @@ class MMDBone:
     additional_transform_bone_id: int
     additional_transform_influence: float
     is_additional_transform_dirty: bool
+    display_connection_bone: str
+    display_connection_bone_id: int
+    display_connection_type: str  # 'BONE', 'OFFSET', 'NONE'
+    display_connection_offset: Vector

--- a/tests/test_pmx_exporter.py
+++ b/tests/test_pmx_exporter.py
@@ -296,7 +296,9 @@ class TestPmxExporter(unittest.TestCase):
             msg = bone0.name
             displayConnection0 = self.__get_bone_display_connection(bone0, source_bones)
             displayConnection1 = self.__get_bone_display_connection(bone1, result_bones)
-            if not isinstance(displayConnection0, str) and not isinstance(displayConnection1, str):
+            if 'nan' in str(displayConnection0):
+                self.assertEqual(str(displayConnection0), str(displayConnection1), msg)
+            elif not isinstance(displayConnection0, str) and not isinstance(displayConnection1, str):
                 self.assertLess(self.__vector_error(displayConnection0, displayConnection1), 1e-4, msg)
             else:
                 self.assertEqual(displayConnection0, displayConnection1, msg)


### PR DESCRIPTION
Fix for issue #156: Ensure bone targeting is preserved correctly when importing/exporting models. This resolves the issue where the 'upper body' bone's targeting changes incorrectly during export.

Users can now edit the bone target using the MMD Bone Tools panel.
<img width="282" alt="Snipaste_2025-04-20_23-21-32" src="https://github.com/user-attachments/assets/1117e4a7-72ef-45f1-b5ff-69fdc972ed82" />
