### PR TITLE
[Bone] Bone collection migration, model join/separation test, and related bug fixes

### DIFF
--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -345,17 +345,8 @@ class FnModel:
             child_bone_morphs = child_root_object.mmd_root.bone_morphs
 
             # Reassign bone IDs to avoid conflicts
-            valid_bones = [pb for pb in child_pose_bones
-                        if not (hasattr(pb, 'is_mmd_shadow_bone') and pb.is_mmd_shadow_bone)
-                        and pb.mmd_bone.bone_id != -1]
-            valid_bones.sort(key=lambda pb: pb.mmd_bone.bone_id)
-            new_id = max_bone_id + 1
-            for bone in valid_bones:
-                if bone.mmd_bone.bone_id != new_id:
-                    FnModel.safe_change_bone_id(bone, new_id, child_bone_morphs, child_pose_bones)
-                    new_id += 1
-
-            max_bone_id = new_id - 1
+            FnModel.realign_bone_ids(child_pose_bones, max_bone_id + 1, child_bone_morphs, child_pose_bones)
+            max_bone_id = FnModel.get_max_bone_id(child_pose_bones)
 
             # Save material morph references
             related_meshes = {}

--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -254,6 +254,11 @@ class FnModel:
         Changes bone ID and updates all references safely by detecting and resolving conflicts automatically.
         If new_bone_id is already in use, shifts all conflicting bone IDs sequentially until a gap is found.
         """
+        # Validate new_bone_id is non-negative
+        if new_bone_id < 0:
+            logging.warning(f"Attempted to set negative bone_id ({new_bone_id}) for bone '{bone.name}'. Using 0 instead.")
+            new_bone_id = 0
+
         # Check if new_bone_id is already in use
         bones_using_id = [pb for pb in pose_bones if pb.mmd_bone.bone_id == new_bone_id]
 

--- a/mmd_tools/m17n.py
+++ b/mmd_tools/m17n.py
@@ -632,6 +632,8 @@ translation_dict = {
         ("*", "Transform Order"): "变形顺序",
         ("Operator", "Add Missing Vertex Groups from Bones"): "从骨骼中添加缺失的顶点组",
         ("*", "Search in all meshes"): "在所有网格中搜索",
+        ("*", "Total Bones"): "骨骼数量",
+        ("Operator", "Fix Bone Order"): "修复骨骼顺序",
 
         # 3D Viewport > Sidebar > Misc > MMD Display Panel
         ("*", "MMD Display"): "MMD显示",
@@ -724,6 +726,8 @@ translation_dict = {
         ("*", "Local Z-Axis"): "局部Z轴",
         ("*", "Rotate +"): "旋转 +",
         ("*", "Move +"): "移动 +",
+        ("*", "Display Connection (Bone Target):"): "骨骼末端指向:",
+        ("*", "Target Bone"): "目标骨骼",
 
         # Shader Editor > Shader Nodes
         ("*", "Base Tex Fac"): "基础纹理系数",

--- a/mmd_tools/m17n.py
+++ b/mmd_tools/m17n.py
@@ -632,7 +632,7 @@ translation_dict = {
         ("*", "Transform Order"): "变形顺序",
         ("Operator", "Add Missing Vertex Groups from Bones"): "从骨骼中添加缺失的顶点组",
         ("*", "Search in all meshes"): "在所有网格中搜索",
-        ("*", "Total Bones"): "骨骼数量",
+        ("*", "Total Bones: %d"): "骨骼数量: %d",
         ("Operator", "Fix Bone Order"): "修复骨骼顺序",
 
         # 3D Viewport > Sidebar > Misc > MMD Display Panel

--- a/mmd_tools/panels/sidebar/bone_order.py
+++ b/mmd_tools/panels/sidebar/bone_order.py
@@ -6,7 +6,7 @@ import bpy
 from ...core.bone import FnBone, MigrationFnBone, BONE_COLLECTION_NAME_SHADOW, BONE_COLLECTION_NAME_DUMMY
 from ...core.model import FnModel
 from . import PT_ProductionPanelBase
-
+from bpy.app.translations import pgettext_iface as _
 
 class MMDToolsBoneIdMoveUp(bpy.types.Operator):
     bl_idname = "mmd_tools.bone_id_move_up"
@@ -562,5 +562,5 @@ class MMDBoneOrder(PT_ProductionPanelBase, bpy.types.Panel):
 
         # Display total bone count with action buttons
         row = col.row(align=True)
-        row.label(text=f"Total Bones: {valid_bone_count}")
+        row.label(text=f"{_('Total Bones')}:{valid_bone_count}")
         row.operator("mmd_tools.fix_bone_order", text="Fix Bone Order", icon="LINENUMBERS_ON")

--- a/mmd_tools/panels/sidebar/bone_order.py
+++ b/mmd_tools/panels/sidebar/bone_order.py
@@ -6,7 +6,6 @@ import bpy
 from ...core.bone import FnBone, MigrationFnBone, BONE_COLLECTION_NAME_SHADOW, BONE_COLLECTION_NAME_DUMMY
 from ...core.model import FnModel
 from . import PT_ProductionPanelBase
-from bpy.app.translations import pgettext_iface as _
 
 class MMDToolsBoneIdMoveUp(bpy.types.Operator):
     bl_idname = "mmd_tools.bone_id_move_up"
@@ -562,5 +561,5 @@ class MMDBoneOrder(PT_ProductionPanelBase, bpy.types.Panel):
 
         # Display total bone count with action buttons
         row = col.row(align=True)
-        row.label(text=f"{_('Total Bones')}:{valid_bone_count}")
+        row.label(text=f"{bpy.app.translations.pgettext_iface('Total Bones')}:{valid_bone_count}")
         row.operator("mmd_tools.fix_bone_order", text="Fix Bone Order", icon="LINENUMBERS_ON")

--- a/mmd_tools/panels/sidebar/bone_order.py
+++ b/mmd_tools/panels/sidebar/bone_order.py
@@ -561,5 +561,5 @@ class MMDBoneOrder(PT_ProductionPanelBase, bpy.types.Panel):
 
         # Display total bone count with action buttons
         row = col.row(align=True)
-        row.label(text=f"{bpy.app.translations.pgettext_iface('Total Bones')}:{valid_bone_count}")
+        row.label(text=bpy.app.translations.pgettext_iface("Total Bones: %d") % valid_bone_count)
         row.operator("mmd_tools.fix_bone_order", text="Fix Bone Order", icon="LINENUMBERS_ON")

--- a/mmd_tools/panels/sidebar/bone_order.py
+++ b/mmd_tools/panels/sidebar/bone_order.py
@@ -268,13 +268,10 @@ class MMDToolsRealignBoneIds(bpy.types.Operator):
                 continue
 
             if bone.name in vg_index_map:
-                bone.mmd_bone.bone_id = next_id
+                FnModel.safe_change_bone_id(bone, next_id, root.mmd_root.bone_morphs, armature.pose.bones)
                 next_id += 1
 
-        # Now realign to make sure there are no gaps
-        FnModel.realign_bone_ids(armature.pose.bones, 0, root.mmd_root.bone_morphs, armature.pose.bones)
-
-        # Remove the mmd_bone_order_override modifier from the mesh
+        # Rename the mmd_bone_order_override modifier of the mesh
         for modifier in mesh_object.modifiers:
             if modifier.name == 'mmd_bone_order_override':
                 modifier.name = 'mmd_armature'

--- a/tests/test_fileio_operators.py
+++ b/tests/test_fileio_operators.py
@@ -65,7 +65,7 @@ class TestFileIoOperators(unittest.TestCase):
             self.assertTrue(os.path.isfile(output_pmx), "File was not created")  # Is this a race condition?
             # Check if the texture was properly copied
             tex_path = os.path.join(os.path.dirname(output_pmx), 'textures', 'blush.png')
-            self.assertTrue(os.path.isfile(tex_path), "Texture not copied properly")
+            self.assertTrue(os.path.isfile(tex_path), f"Texture not copied properly. Expected file at: {tex_path}")
             # Load the resultant pmx file and check the material order is the expected
             result_model = pmx.load(output_pmx)
             result_material_names = [mat.name for mat in result_model.materials]

--- a/tests/text_model_edit.py
+++ b/tests/text_model_edit.py
@@ -1,0 +1,600 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import shutil
+import unittest
+import logging
+
+import bpy
+context = bpy.context
+from mathutils import Vector
+
+from bl_ext.user_default.mmd_tools.core import pmx
+from bl_ext.user_default.mmd_tools.core.bone import FnBone, MigrationFnBone
+from bl_ext.user_default.mmd_tools.core.model import Model, FnModel
+from bl_ext.user_default.mmd_tools.core.pmx.importer import PMXImporter
+
+sys.path.append(os.getcwd())
+#from tests.test_pmx_exporter import TestPmxExporter
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+SAMPLES_DIR = os.path.join(os.path.dirname(TESTS_DIR), 'samples')
+
+class TestModelEdit(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # Clean up output from previous tests
+        output_dir = os.path.join(TESTS_DIR, 'output')
+        for item in os.listdir(output_dir):
+            if item.endswith('.OUTPUT'):
+                continue  # Skip the placeholder
+            item_fp = os.path.join(output_dir, item)
+            if os.path.isfile(item_fp):
+                os.remove(item_fp)
+            elif os.path.isdir(item_fp):
+                shutil.rmtree(item_fp)
+
+    def setUp(self):
+        # Set up logging and clear the Blender scene
+        logger = logging.getLogger()
+        logger.setLevel('ERROR')
+
+        # Clear the scene
+        bpy.ops.wm.read_homefile()
+
+    #********************************************
+    # Utils
+    #********************************************
+
+    def __create_test_collection(self, name="MMD_Test_Collection"):
+        """Create a dedicated collection for testing"""
+        # Remove collection if it already exists
+        if name in bpy.data.collections:
+            collection = bpy.data.collections[name]
+            bpy.data.collections.remove(collection)
+
+        # Create new collection
+        collection = bpy.data.collections.new(name)
+        context.scene.collection.children.link(collection)
+        return collection
+
+    def __list_sample_files(self, file_types):
+        ret = []
+        for file_type in file_types:
+            file_ext = '.' + file_type
+            for root, dirs, files in os.walk(os.path.join(SAMPLES_DIR, file_type)):
+                for name in files:
+                    if name.lower().endswith(file_ext):
+                        ret.append(os.path.join(root, name))
+        return ret
+
+    def __enable_mmd_tools(self):
+        bpy.ops.wm.read_homefile()  # reload blender startup file
+        pref = getattr(context, 'preferences', None) or context.user_preferences
+        if not pref.addons.get('mmd_tools', None):
+            addon_enable = bpy.ops.wm.addon_enable if 'addon_enable' in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
+            addon_enable(module='bl_ext.user_default.mmd_tools')  # make sure addon 'mmd_tools' is enabled
+
+    def __is_object_in_collection(self, obj, collection):
+        """Safely check if an object is in a collection"""
+        for o in collection.objects:
+            if o == obj:
+                return True
+        return False
+
+    def __import_pmx_models(self, filepaths, collection, scale=1.0):
+        """Import PMX models into the specified collection"""
+        imported_models = []
+
+        # Set the active collection
+        layer_collection = context.view_layer.layer_collection
+        for child in layer_collection.children:
+            if child.collection == collection:
+                layer_collection = child
+                break
+        context.view_layer.active_layer_collection = layer_collection
+
+        for filepath in filepaths:
+            # Import the PMX model
+            model = pmx.load(filepath)
+            importer = PMXImporter()
+            importer.execute(
+                pmx=model,
+                types={'MESH', 'ARMATURE', 'PHYSICS', 'DISPLAY', 'MORPHS'},
+                scale=scale,
+                clean_model=False,
+            )
+
+        # Find all root objects and ensure they're in our collection
+        for obj in context.scene.objects:
+            if obj.mmd_type == 'ROOT':
+                if not self.__is_object_in_collection(obj, collection):
+                    # Move the root to our collection
+                    scene_collection = context.scene.collection
+                    if obj.name in scene_collection.objects:
+                        scene_collection.objects.unlink(obj)
+                    collection.objects.link(obj)
+
+                # Also move all children recursively
+                self.__move_children_to_collection(obj, collection)
+
+                # Add to our imported models list
+                imported_models.append(obj)
+
+        return imported_models
+
+    def __move_children_to_collection(self, parent_obj, collection):
+        """Recursively move all children of an object to the specified collection"""
+        for child in parent_obj.children:
+            # Check if the child is not already in our collection
+            if not self.__is_object_in_collection(child, collection):
+                # Unlink from other collections
+                for col in bpy.data.collections:
+                    if child.name in col.objects:
+                        col.objects.unlink(child)
+                # Link to our collection
+                collection.objects.link(child)
+
+            # Process children recursively
+            self.__move_children_to_collection(child, collection)
+
+    def __test_import_export_cycle(self, pmx_file_path):
+        """Test importing and exporting a PMX file"""
+
+        # Clear the scene
+        bpy.ops.wm.read_homefile()
+
+        # Enable mmd_tools addon
+        self.__enable_mmd_tools()
+
+        # Import the PMX file
+        print(f"\nTesting import/export cycle with file: {pmx_file_path}")
+        print("test importing")
+        source_model = pmx.load(pmx_file_path)
+
+        PMXImporter().execute(
+            pmx=source_model,
+            types={'MESH', 'ARMATURE', 'PHYSICS', 'DISPLAY', 'MORPHS'},
+            scale=1,
+            clean_model=False,
+        )
+
+        # Update scene
+        context.view_layer.update()
+
+        # Export to a new file
+        print("test exporting")
+        output_pmx = os.path.join(TESTS_DIR, 'output', 'import_export_test.pmx')
+        bpy.ops.mmd_tools.export_pmx(
+            filepath=output_pmx,
+            scale=1,
+            copy_textures=False,
+            sort_materials=False,
+            log_level='ERROR',
+        )
+
+        print(f"Exported test model to: {output_pmx}")
+        self.assertTrue(os.path.isfile(output_pmx), "Re-exported file was not created")
+
+        return output_pmx
+
+    def __test_joined_model(self, joined_model_path):
+        """Test the exported joined model for validity"""
+
+        # Clear the scene
+        bpy.ops.wm.read_homefile()
+
+        # Enable mmd_tools addon
+        self.__enable_mmd_tools()
+
+        # Import the joined model
+        print(f"\nTesting joined model: {joined_model_path}")
+        try:
+            # Load the PMX model
+            joined_model = pmx.load(joined_model_path)
+
+            # Import the model into Blender
+            PMXImporter().execute(
+                pmx=joined_model,
+                types={'MESH', 'ARMATURE', 'PHYSICS', 'DISPLAY', 'MORPHS'},
+                scale=1,
+                clean_model=False,
+            )
+
+            # Update scene
+            context.view_layer.update()
+
+            # Basic validation - check if we have bones, vertices, and materials
+            self.assertTrue(len(joined_model.bones) > 0, "Joined model has no bones")
+            self.assertTrue(len(joined_model.vertices) > 0, "Joined model has no vertices")
+            self.assertTrue(len(joined_model.materials) > 0, "Joined model has no materials")
+
+            # Check for key bones from both models
+            has_head_bone = False
+            has_neck_bone = False
+            for bone in joined_model.bones:
+                if bone.name == '頭':
+                    has_head_bone = True
+                elif bone.name == '首':
+                    has_neck_bone = True
+
+            print(f"    Total bones: {len(joined_model.bones)}")
+
+            self.assertTrue(has_head_bone, "Joined model is missing the '頭' (head) bone")
+            self.assertTrue(has_neck_bone, "Joined model is missing the '首' (neck) bone")
+
+            # Check if the model was correctly imported into Blender
+            armatures = [obj for obj in bpy.data.objects if obj.type == 'ARMATURE']
+            self.assertTrue(len(armatures) > 0, "No armatures were imported into Blender")
+
+            # Now re-export the model to test roundtrip conversion
+            export_path = os.path.join(TESTS_DIR, 'output', 'joined_model_roundtrip.pmx')
+            bpy.ops.mmd_tools.export_pmx(
+                filepath=export_path,
+                scale=1,
+                copy_textures=False,
+                sort_materials=False,
+                log_level='ERROR',
+            )
+            print("Joined model passed all validation tests!")
+            return True
+
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            self.fail(f"Joined model testing failed with error: {e}")
+            return False
+
+    def test_model_separation_and_join(self):
+        # Test the model separation and joining functionality
+        # Enable mmd_tools
+        self.__enable_mmd_tools()
+
+        # Create a dedicated collection for our test
+        test_collection = self.__create_test_collection("MMD_Models")
+
+        # Get sample PMX files
+        pmx_files = self.__list_sample_files(['pmx'])
+        if len(pmx_files) < 2:
+            self.skipTest("Need at least 2 PMX sample files for this test")
+
+        # Use the first two PMX files
+        test_files = pmx_files[:2]
+        print(f"\nTesting with PMX files:\n - {test_files[0]}\n - {test_files[1]}")
+
+        try:
+            # Import the models into our collection
+            pmx_models = self.__import_pmx_models(test_files, test_collection)
+            self.assertEqual(len(pmx_models), 2, "Failed to import two models")
+
+            # Keep track of all model roots in our collection before separation
+            existing_roots = []
+            for obj in test_collection.objects:
+                if obj.mmd_type == 'ROOT':
+                    existing_roots.append(obj)
+
+            print(f"\nBefore separation - Model roots: {[root.name for root in existing_roots]}")
+
+            # For each model, directly find the '頭' bone and use it for separation
+            for model_root in existing_roots:
+                # Get the armature object
+                armature = None
+                for child in model_root.children:
+                    if child.type == 'ARMATURE':
+                        armature = child
+                        break
+
+                if not armature:
+                    self.fail(f"No armature found in model {model_root.name}")
+
+                # Enter pose mode
+                context.view_layer.objects.active = armature
+                bpy.ops.object.mode_set(mode='POSE')
+
+                # Deselect all bones
+                for bone in armature.pose.bones:
+                    bone.bone.select = False
+
+                # Directly find and use the '頭' bone
+                head_bone = None
+                for bone in armature.pose.bones:
+                    if bone.name == '頭':
+                        head_bone = bone
+                        break
+
+                if not head_bone:
+                    self.fail(f"Could not find '頭' bone in model {model_root.name}")
+
+                print(f"Using bone '{head_bone.name}' for model separation in {model_root.name}")
+                head_bone.bone.select = True
+                armature.data.bones.active = head_bone.bone
+
+                # Execute separation
+                bpy.ops.mmd_tools.model_separate_by_bones(
+                    separate_armature=True,
+                    include_descendant_bones=True,
+                    boundary_joint_owner='DESTINATION'
+                )
+
+                # Return to object mode
+                bpy.ops.object.mode_set(mode='OBJECT')
+
+                # Make sure new objects are in our collection
+                for obj in context.scene.objects:
+                    if obj.mmd_type == 'ROOT' and not self.__is_object_in_collection(obj, test_collection):
+                        # Add to collection
+                        test_collection.objects.link(obj)
+                        # Also move all children
+                        self.__move_children_to_collection(obj, test_collection)
+
+            # After separation, find all the armatures and roots in our collection
+            all_roots = []
+            for obj in test_collection.objects:
+                if obj.mmd_type == 'ROOT':
+                    all_roots.append(obj)
+
+            all_armatures = []
+            for obj in bpy.data.objects:
+                if obj.type == 'ARMATURE':
+                    # Check if this armature is in our test collection
+                    if self.__is_object_in_collection(obj, test_collection):
+                        all_armatures.append(obj)
+
+            print(f"\nAfter separation - All model roots: {[root.name for root in all_roots]}")
+            print(f"After separation - All armatures: {[arm.name for arm in all_armatures]}")
+
+            # Get bone information for each armature
+            armatures_with_bone_info = []
+            for arm in all_armatures:
+                # Count bones with specific names
+                head_bones = [b for b in arm.pose.bones if b.name in ['頭', 'head', 'Head']]
+                neck_bones = [b for b in arm.pose.bones if b.name in ['首', 'neck', 'Neck']]
+
+                print(f"Armature: {arm.name}")
+                print(f"    Total bones: {len(arm.pose.bones)}")
+                print(f"    Has head bones: {[b.name for b in head_bones]}")
+                print(f"    Has neck bones: {[b.name for b in neck_bones]}")
+
+                armatures_with_bone_info.append({
+                    'armature': arm,
+                    'bone_count': len(arm.pose.bones),
+                    'head_bones': head_bones,
+                    'neck_bones': neck_bones
+                })
+
+            # Get the original model names from before separation
+            original_model_names = [root.name for root in existing_roots]
+
+            # Find armatures based on the naming pattern from the original models
+            first_model_arm = None
+            second_model_arm_with_head = None
+
+            # First model's primary armature with '首' bone
+            for arm_info in armatures_with_bone_info:
+                arm_name = arm_info['armature'].name
+                if arm_name == original_model_names[0] + "_arm" and arm_info['neck_bones']:
+                    first_model_arm = arm_info['armature']
+                    break
+
+            # Second model's separated armature with '頭' bone
+            for arm_info in armatures_with_bone_info:
+                arm_name = arm_info['armature'].name
+                if original_model_names[1] + "_arm" in arm_name and ".001" in arm_name and arm_info['head_bones']:
+                    second_model_arm_with_head = arm_info['armature']
+                    break
+
+            if not first_model_arm:
+                self.fail("Could not find the first model's armature with '首' bone")
+
+            if not second_model_arm_with_head:
+                self.fail("Could not find the second model's armature with '頭' bone")
+
+            print(f"\nSelected armatures for joining:")
+            print(f"    First model armature: {first_model_arm.name}")
+            print(f"    Second model armature: {second_model_arm_with_head.name}")
+
+            # Find the roots of the armatures
+            first_model_root = first_model_arm.parent
+            second_model_root = second_model_arm_with_head.parent
+
+            if not first_model_root or not second_model_root:
+                self.fail("Could not find the root objects for the selected armatures")
+
+            # First, ensure we're in object mode
+            bpy.ops.object.mode_set(mode='OBJECT')
+
+            # Deselect all objects
+            bpy.ops.object.select_all(action='DESELECT')
+
+            # Select both root objects and make the first one active
+            first_model_root.select_set(True)
+            second_model_root.select_set(True)
+            context.view_layer.objects.active = first_model_root
+
+            # Now, select and make active the first armature
+            bpy.ops.object.select_all(action='DESELECT')
+            first_model_arm.select_set(True)
+            context.view_layer.objects.active = first_model_arm
+
+            # Enter pose mode
+            bpy.ops.object.mode_set(mode='POSE')
+
+            # Deselect all bones
+            for bone in first_model_arm.pose.bones:
+                bone.bone.select = False
+
+            # Find and select the '首' bone in the first model
+            neck_bone = None
+            for bone in first_model_arm.pose.bones:
+                if bone.name == '首':
+                    neck_bone = bone
+                    break
+
+            if not neck_bone:
+                self.fail("Could not find '首' bone in the first model's armature")
+
+            # Select the neck bone and make it active
+            neck_bone.bone.select = True
+            first_model_arm.data.bones.active = neck_bone.bone
+
+            # Return to object mode
+            bpy.ops.object.mode_set(mode='OBJECT')
+
+            # Now, select the second armature and make it active
+            bpy.ops.object.select_all(action='DESELECT')
+            second_model_arm_with_head.select_set(True)
+            context.view_layer.objects.active = second_model_arm_with_head
+
+            # Enter pose mode
+            bpy.ops.object.mode_set(mode='POSE')
+
+            # Deselect all bones
+            for bone in second_model_arm_with_head.pose.bones:
+                bone.bone.select = False
+
+            # Find and select the '頭' bone in the second model
+            head_bone = None
+            for bone in second_model_arm_with_head.pose.bones:
+                if bone.name == '頭':
+                    head_bone = bone
+                    break
+
+            if not head_bone:
+                self.fail("Could not find '頭' bone in the second model's armature")
+
+            # Select the head bone
+            head_bone.bone.select = True
+            second_model_arm_with_head.data.bones.active = head_bone.bone
+
+            # Return to object mode
+            bpy.ops.object.mode_set(mode='OBJECT')
+
+            # Select both model roots again for the join operation
+            bpy.ops.object.select_all(action='DESELECT')
+            first_model_root.select_set(True)
+            second_model_root.select_set(True)
+
+            # Set the active object to the first model root
+            context.view_layer.objects.active = first_model_root
+
+            print(f"Joining using bones: '{neck_bone.name}' from '{first_model_arm.name}' and '{head_bone.name}' from '{second_model_arm_with_head.name}'")
+
+            # First, collect the objects to be removed
+            objects_to_remove = []
+            for obj in bpy.data.objects:
+                if obj.type == 'ARMATURE' and obj != first_model_arm and obj != second_model_arm_with_head:
+                    objects_to_remove.append(obj)
+                elif obj.mmd_type == 'ROOT' and obj != first_model_root and obj != second_model_root:
+                    objects_to_remove.append(obj)
+            # Then remove them in a separate loop
+            for obj in objects_to_remove:
+                if obj.name in bpy.data.objects:
+                    print(f"Removing unnecessary object: {obj.name} ({obj.type})")
+                    bpy.data.objects.remove(obj)
+
+            # Select the specific armatures again and enter pose mode on the first armature
+            bpy.ops.object.select_all(action='DESELECT')
+            first_model_arm.select_set(True)
+            second_model_arm_with_head.select_set(True)
+            context.view_layer.objects.active = first_model_arm
+
+            for arm in [first_model_arm, second_model_arm_with_head]:
+                head_bones = [b for b in arm.pose.bones if b.name in ['頭', 'head', 'Head']]
+                neck_bones = [b for b in arm.pose.bones if b.name in ['首', 'neck', 'Neck']]
+                print(f"Armature: {arm.name}")
+                print(f"    Total bones: {len(arm.pose.bones)}")
+                print(f"    Has head bones: {[b.name for b in head_bones]}")
+                print(f"    Has neck bones: {[b.name for b in neck_bones]}")
+
+            context.view_layer.objects.active = first_model_arm
+
+            # Enter pose mode on the active armature
+            bpy.ops.object.mode_set(mode='POSE')
+
+            # Select the bones in the armatures
+            for bone in first_model_arm.pose.bones:
+                bone.bone.select = False
+            neck_bone.bone.select = True
+            for bone in second_model_arm_with_head.pose.bones:
+                bone.bone.select = False
+            head_bone.bone.select = True
+
+            selected_bones = context.selected_pose_bones
+            print(f"Selected {len(selected_bones)} bones:")
+            for i, bone in enumerate(selected_bones, 1):
+                print(f"{i}. {bone.name}")
+
+            # context.view_layer.update()
+
+            # Execute join
+            bpy.ops.mmd_tools.model_join_by_bones(join_type='OFFSET')
+
+            # Return to object mode
+            bpy.ops.object.mode_set(mode='OBJECT')
+
+            # Check the result - get all roots in our collection
+            final_roots = []
+            for obj in test_collection.objects:
+                if obj.mmd_type == 'ROOT':
+                    final_roots.append(obj)
+
+            print(f"\nAfter joining - Model roots: {[root.name for root in final_roots]}")
+
+            # Find the joined model's root (should be the first model's root)
+            joined_model_root = first_model_root
+            print(f"Joined model root: {joined_model_root.name}")
+
+            # Identify the main armature of the joined model
+            joined_model_armature = FnModel.find_armature_object(joined_model_root)
+
+            arm = joined_model_armature
+            head_bones = [b for b in arm.pose.bones if b.name in ['頭', 'head', 'Head']]
+            neck_bones = [b for b in arm.pose.bones if b.name in ['首', 'neck', 'Neck']]
+            print(f"Armature: {arm.name}")
+            print(f"    Total bones: {len(arm.pose.bones)}")
+            print(f"    Has head bones: {[b.name for b in head_bones]}")
+            print(f"    Has neck bones: {[b.name for b in neck_bones]}")
+
+            # Ensure we're in object mode
+            bpy.ops.object.mode_set(mode='OBJECT')
+
+            # Deselect all objects and select the joined model root
+            bpy.ops.object.select_all(action='DESELECT')
+            joined_model_root.select_set(True)
+            context.view_layer.objects.active = joined_model_root
+
+            # Export the joined model
+            output_pmx = os.path.join(TESTS_DIR, 'output', 'joined_model.pmx')
+
+            bpy.ops.mmd_tools.export_pmx(
+                filepath=output_pmx,
+                scale=1,
+                copy_textures=False,
+                sort_materials=False,
+                log_level='ERROR',
+            )
+
+            # Verify the file was created
+            self.assertTrue(os.path.isfile(output_pmx), "Exported PMX file was not created")
+
+            # Now test the joined model properly
+            self.__test_joined_model(output_pmx)
+
+            # Also do a standard import/export cycle test
+            output_pmx_2 = self.__test_import_export_cycle(output_pmx)
+
+            # Verify both exported files exist
+            self.assertTrue(os.path.isfile(output_pmx), "First exported PMX file was not created")
+            self.assertTrue(os.path.isfile(output_pmx_2), "Second exported PMX file was not created")
+
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            self.fail(f"Test failed with error: {e}")
+
+if __name__ == '__main__':
+    import sys
+    sys.argv = [__file__] + (sys.argv[sys.argv.index('--') + 1:] if '--' in sys.argv else [])
+    unittest.main()


### PR DESCRIPTION
This PR addresses issues related to bone collection migration for Blender 4 and later. It also adds test cases for model joining/separation and fixes incorrect bone_id handling. Minor translation updates are included.

Fix migration from Blender 3.6 or earlier
```
"C:\Users\user\AppData\Roaming\Blender Foundation\Blender\4.4\extensions\user_default\mmd_tools\core\bone.py", line 136, in set_edit_bone_to_dummy
    return FnBone.set_edit_bone_to_special(edit_bone, BONE_COLLECTION_NAME_DUMMY)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\user\AppData\Roaming\Blender Foundation\Blender\4.4\extensions\user_default\mmd_tools\core\bone.py", line 130, in set_edit_bone_to_special
    edit_bone.id_data.collections[bone_collection_name].assign(edit_bone)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'bpy_prop_collection[key]: key "mmd_dummy" not found'
```

The migration function of the "Fix Bone Order" button now works properly when migrating from models imported using either mmd_tools ≤ v2.10.3 or ≤ v4.3.1:
(It's a gif image demo.)
![!50](https://github.com/user-attachments/assets/6c0f1beb-2338-46b7-a4ea-b4623ac3cc7b)
