### PR TITLE
Fix rigid body size property not updating correctly

### DIFF
--- a/mmd_tools/properties/rigid_body.py
+++ b/mmd_tools/properties/rigid_body.py
@@ -141,6 +141,10 @@ def _set_size(prop, value):
                 v.co = [x0, y0, z0]
         mesh.update()
 
+    # IMPORTANT: Update view layer AFTER geometry changes are complete
+    # This ensures bounding box is current for subsequent getter calls
+    bpy.context.view_layer.update()
+
 
 def _get_rigid_name(prop):
     return prop.get("name", "")


### PR DESCRIPTION
Fixes an issue where the rigid body size property would return stale values after being set to new values.
The getter now correctly reflects changes made by the setter.