### PR TITLE
Fix performance regression in PMX import, optimize vertex morph import, and improve PMX header diagnostics

### DIFF
--- a/mmd_tools/core/pmx/__init__.py
+++ b/mmd_tools/core/pmx/__init__.py
@@ -260,19 +260,19 @@ class Header:
         return 4
 
     def load(self, fs):
-        logging.info("loading pmx header information...")
+        logging.debug("loading pmx header information...")
         self.sign = fs.readBytes(4)
         logging.debug("File signature is %s", self.sign)
         if self.sign[:3] != self.PMX_SIGN[:3]:
-            logging.error("File signature is invalid")
+            logging.error("File signature is invalid: %s", self.sign)
             logging.error("This file is unsupported format, or corrupt file.")
             raise InvalidFileError("File signature is invalid.")
         self.version = fs.readFloat()
-        logging.info("pmx format version: %f", self.version)
+        logging.debug("pmx format version: %f", self.version)
         if self.version != self.VERSION:
             logging.error("PMX version %.1f is unsupported", self.version)
             raise UnsupportedVersionError("unsupported PMX version: %.1f" % self.version)
-        if fs.readByte() != 8 or self.sign[3] != self.PMX_SIGN[3]:
+        if fs.readByte() != 8:
             logging.warning(" * This file might be corrupted.")
         self.encoding = Encoding(fs.readByte())
         self.additional_uvs = fs.readByte()

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -392,7 +392,7 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
 class ImportVmd(Operator, ImportHelper, PreferencesMixin):
     bl_idname = "mmd_tools.import_vmd"
     bl_label = "Import VMD File (.vmd)"
-    bl_description = "Import a VMD file to selected objects (.vmd)"
+    bl_description = "Import a VMD file to selected objects (.vmd)\nBehavior varies depending on the selected object:\n- Select the root (cross under the model): imports both armature and morph animations\n- Select the model: imports only morph animation\n- Select the armature: imports only armature animation"
     bl_options = {"REGISTER", "UNDO", "PRESET"}
 
     files: bpy.props.CollectionProperty(type=OperatorFileListElement, options={"HIDDEN", "SKIP_SAVE"})
@@ -565,7 +565,7 @@ class ImportVmd(Operator, ImportHelper, PreferencesMixin):
 class ImportVpd(Operator, ImportHelper, PreferencesMixin):
     bl_idname = "mmd_tools.import_vpd"
     bl_label = "Import VPD File (.vpd)"
-    bl_description = "Import VPD file(s) to selected rig's Action Pose (.vpd)"
+    bl_description = "Import VPD file(s) to selected rig's Action Pose (.vpd)\nBehavior varies depending on the selected object:\n- Select the root (cross under the model): applies both armature pose and morphs\n- Select the model: applies only morphs\n- Select the armature: applies only armature pose"
     bl_options = {"REGISTER", "UNDO", "PRESET"}
 
     files: bpy.props.CollectionProperty(type=OperatorFileListElement, options={"HIDDEN", "SKIP_SAVE"})
@@ -879,7 +879,7 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
 class ExportVmd(Operator, ExportHelper, PreferencesMixin):
     bl_idname = "mmd_tools.export_vmd"
     bl_label = "Export VMD File (.vmd)"
-    bl_description = "Export motion data of active object to a VMD file (.vmd)"
+    bl_description = "Export motion data of active object to a VMD file (.vmd)\nBehavior varies depending on the active object:\n- Active object is the root (cross under the model): exports both armature and morph animations\n- Active object is the model: exports only morph animation\n- Active object is the armature: exports only armature animation"
     bl_options = {"PRESET"}
 
     filename_ext = ".vmd"
@@ -973,7 +973,7 @@ class ExportVmd(Operator, ExportHelper, PreferencesMixin):
 class ExportVpd(Operator, ExportHelper, PreferencesMixin):
     bl_idname = "mmd_tools.export_vpd"
     bl_label = "Export VPD File (.vpd)"
-    bl_description = "Export active rig's Action Pose to VPD file(s) (.vpd)"
+    bl_description = "Export active rig's Action Pose to VPD file(s) (.vpd)\nBehavior varies depending on the active object:\n- Active object is the root (cross under the model): exports both armature pose and morphs\n- Active object is the model: exports only morphs\n- Active object is the armature: exports only armature pose"
     bl_options = {"PRESET"}
 
     filename_ext = ".vpd"

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -211,7 +211,7 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
     bl_options = {"REGISTER", "UNDO", "PRESET"}
 
     files: bpy.props.CollectionProperty(type=OperatorFileListElement, options={"HIDDEN", "SKIP_SAVE"})
-    directory: bpy.props.StringProperty(maxlen=1024, subtype="FILE_PATH", options={"HIDDEN", "SKIP_SAVE"})
+    directory: bpy.props.StringProperty(maxlen=1024, subtype="DIR_PATH", options={"HIDDEN", "SKIP_SAVE"})
 
     filename_ext = ".pmx"
     filter_glob: bpy.props.StringProperty(default="*.pmx;*.pmd", options={"HIDDEN"})
@@ -395,6 +395,9 @@ class ImportVmd(Operator, ImportHelper, PreferencesMixin):
     bl_description = "Import a VMD file to selected objects (.vmd)"
     bl_options = {"REGISTER", "UNDO", "PRESET"}
 
+    files: bpy.props.CollectionProperty(type=OperatorFileListElement, options={"HIDDEN", "SKIP_SAVE"})
+    directory: bpy.props.StringProperty(maxlen=1024, subtype="DIR_PATH", options={"HIDDEN", "SKIP_SAVE"})
+
     filename_ext = ".vmd"
     filter_glob: bpy.props.StringProperty(default="*.vmd", options={"HIDDEN"})
 
@@ -477,10 +480,6 @@ class ImportVmd(Operator, ImportHelper, PreferencesMixin):
         description="When the interval between light keyframes is 1 frame, change the interpolation to CONSTANT. This is useful when making a 60fps video, as it helps prevent unwanted smoothing during sudden lighting changes.",
         default=True,
     )
-    files: bpy.props.CollectionProperty(
-        type=OperatorFileListElement,
-    )
-    directory: bpy.props.StringProperty(subtype="DIR_PATH")
 
     @classmethod
     def poll(cls, context):
@@ -570,7 +569,7 @@ class ImportVpd(Operator, ImportHelper, PreferencesMixin):
     bl_options = {"REGISTER", "UNDO", "PRESET"}
 
     files: bpy.props.CollectionProperty(type=OperatorFileListElement, options={"HIDDEN", "SKIP_SAVE"})
-    directory: bpy.props.StringProperty(maxlen=1024, subtype="FILE_PATH", options={"HIDDEN", "SKIP_SAVE"})
+    directory: bpy.props.StringProperty(maxlen=1024, subtype="DIR_PATH", options={"HIDDEN", "SKIP_SAVE"})
 
     filename_ext = ".vpd"
     filter_glob: bpy.props.StringProperty(default="*.vpd", options={"HIDDEN"})

--- a/mmd_tools/properties/rigid_body.py
+++ b/mmd_tools/properties/rigid_body.py
@@ -141,10 +141,6 @@ def _set_size(prop, value):
                 v.co = [x0, y0, z0]
         mesh.update()
 
-    # IMPORTANT: Update view layer AFTER geometry changes are complete
-    # This ensures bounding box is current for subsequent getter calls
-    bpy.context.view_layer.update()
-
 
 def _get_rigid_name(prop):
     return prop.get("name", "")

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -820,6 +820,7 @@ class TestMMDProperties(unittest.TestCase):
         # Test size property
         test_size = [2.0, 3.0, 4.0]
         mmd_rigid.size = test_size
+        bpy.context.view_layer.update()
 
         # Size property has custom getter/setter, so we check if it was applied
         current_size = list(mmd_rigid.size)
@@ -1824,6 +1825,7 @@ class TestMMDProperties(unittest.TestCase):
 
             # Set new size
             mmd_rigid.size = test_size
+            bpy.context.view_layer.update()
 
             # Get size after setting
             new_size = list(mmd_rigid.size)
@@ -1896,8 +1898,11 @@ class TestMMDProperties(unittest.TestCase):
 
         for test_size in edge_cases:
             mmd_rigid.size = [1.0, 1.0, 1.0]
+            bpy.context.view_layer.update()
             initial_size = list(mmd_rigid.size)
+
             mmd_rigid.size = test_size
+            bpy.context.view_layer.update()
             new_size = list(mmd_rigid.size)
 
             # Verify size actually changed from initial when setting edge cases
@@ -1914,6 +1919,7 @@ class TestMMDProperties(unittest.TestCase):
         # Test very large sizes
         large_size = [100.0, 100.0, 100.0]
         mmd_rigid.size = large_size
+        bpy.context.view_layer.update()
         new_size = list(mmd_rigid.size)
 
         # Should handle large sizes without issues
@@ -1940,6 +1946,7 @@ class TestMMDProperties(unittest.TestCase):
         # Set initial size
         initial_size = [1.0, 1.0, 1.0]
         mmd_rigid.size = initial_size
+        bpy.context.view_layer.update()
 
         # Get initial mesh state
         mesh = rigid_obj.data
@@ -1952,6 +1959,7 @@ class TestMMDProperties(unittest.TestCase):
         # Change size significantly
         new_size = [2.0, 3.0, 0.5]
         mmd_rigid.size = new_size
+        bpy.context.view_layer.update()
 
         # Check that mesh was updated
         updated_vertices = [v.co.copy() for v in mesh.vertices]


### PR DESCRIPTION
- Fixed a performance regression introduced in PMX import.
- Further improved performance by optimizing vertex morph import using batch processing.
- Improved diagnostics for invalid PMX file headers.
- Improve VMD/VPD import-export descriptions.
- Fix "directory expected a string with a 'DIR_PATH' subtype" warnings.
- Improve code consistency.