### PR TITLE
Address Ruff linting, add bone-to-vertex morph conversion feature, and apply minor performance and bug fixes

### DIFF
--- a/locales/ja_JP.po
+++ b/locales/ja_JP.po
@@ -1057,11 +1057,11 @@ msgstr "ボーンを英語にリネーム"
 msgid "Translate bone names from Japanese to English using selected dictionary"
 msgstr ""
 
-#. :src: bpy.types.MMD_TOOLS_OT_import_model.fix_IK_links
+#. :src: bpy.types.MMD_TOOLS_OT_import_model.fix_ik_links
 msgid "Fix IK Links"
 msgstr "IKリンクを修正"
 
-#. :src: bpy.types.MMD_TOOLS_OT_import_model.fix_IK_links
+#. :src: bpy.types.MMD_TOOLS_OT_import_model.fix_ik_links
 msgid "Fix IK links to be blender suitable"
 msgstr ""
 
@@ -1211,11 +1211,11 @@ msgstr "シーン設定を更新"
 msgid "Update frame range and frame rate (30 fps)"
 msgstr ""
 
-#. :src: bpy.types.MMD_TOOLS_OT_import_vmd.use_NLA
+#. :src: bpy.types.MMD_TOOLS_OT_import_vmd.use_nla
 msgid "Use NLA"
 msgstr "NLAを使用"
 
-#. :src: bpy.types.MMD_TOOLS_OT_import_vmd.use_NLA
+#. :src: bpy.types.MMD_TOOLS_OT_import_vmd.use_nla
 msgid "Import the motion as NLA strips"
 msgstr ""
 

--- a/locales/zh_HANS.po
+++ b/locales/zh_HANS.po
@@ -1052,11 +1052,11 @@ msgstr "将骨骼重命名为英文"
 msgid "Translate bone names from Japanese to English using selected dictionary"
 msgstr "使用选中的词典将骨骼名从日语翻译为英语"
 
-#. :src: bpy.types.MMD_TOOLS_OT_import_model.fix_IK_links
+#. :src: bpy.types.MMD_TOOLS_OT_import_model.fix_ik_links
 msgid "Fix IK Links"
 msgstr "修复IK关联"
 
-#. :src: bpy.types.MMD_TOOLS_OT_import_model.fix_IK_links
+#. :src: bpy.types.MMD_TOOLS_OT_import_model.fix_ik_links
 msgid "Fix IK links to be blender suitable"
 msgstr "修复逆向运动学关联，使其适合被 Blender 处理"
 
@@ -1206,11 +1206,11 @@ msgstr "更新场景设置"
 msgid "Update frame range and frame rate (30 fps)"
 msgstr "更新帧范围与帧率 (30 FPS)"
 
-#. :src: bpy.types.MMD_TOOLS_OT_import_vmd.use_NLA
+#. :src: bpy.types.MMD_TOOLS_OT_import_vmd.use_nla
 msgid "Use NLA"
 msgstr "使用NLA"
 
-#. :src: bpy.types.MMD_TOOLS_OT_import_vmd.use_NLA
+#. :src: bpy.types.MMD_TOOLS_OT_import_vmd.use_nla
 msgid "Import the motion as NLA strips"
 msgstr "将动作导入为非线性动作片段"
 

--- a/mmd_tools/auto_load.py
+++ b/mmd_tools/auto_load.py
@@ -107,7 +107,7 @@ def get_dependency_from_annotation(value):
         if isinstance(value, bpy.props._PropertyDeferred):
             return value.keywords.get("type")
     elif isinstance(value, tuple) and len(value) == 2:
-        if value[0] in (bpy.props.PointerProperty, bpy.props.CollectionProperty):
+        if value[0] in {bpy.props.PointerProperty, bpy.props.CollectionProperty}:
             return value[1]["type"]
     return None
 

--- a/mmd_tools/auto_load.py
+++ b/mmd_tools/auto_load.py
@@ -141,13 +141,13 @@ def iter_classes_in_module(module):
 
 
 def get_register_base_types():
-    return set(getattr(bpy.types, name) for name in [
+    return {getattr(bpy.types, name) for name in [
         "Panel", "Operator", "PropertyGroup",
         "AddonPreferences", "Header", "Menu",
         "Node", "NodeSocket", "NodeTree",
         "UIList", "RenderEngine",
         "Gizmo", "GizmoGroup",
-    ])
+    ]}
 
 
 # Find order to register to solve dependencies

--- a/mmd_tools/auto_load.py
+++ b/mmd_tools/auto_load.py
@@ -129,8 +129,7 @@ def iter_my_classes(modules):
 def get_classes_in_modules(modules):
     classes = set()
     for module in modules:
-        for cls in iter_classes_in_module(module):
-            classes.add(cls)
+        classes.update(iter_classes_in_module(module))
     return classes
 
 

--- a/mmd_tools/auto_load.py
+++ b/mmd_tools/auto_load.py
@@ -1,3 +1,6 @@
+# Copyright 2021 MMD Tools authors
+# This file is part of MMD Tools.
+
 import importlib
 import inspect
 import pkgutil

--- a/mmd_tools/bpyutils.py
+++ b/mmd_tools/bpyutils.py
@@ -54,7 +54,7 @@ class __SelectObjects:
             i.select_set(False)
 
         self.__active_object = active_object
-        self.__selected_objects = tuple(set(selected_objects) | set([active_object])) if selected_objects else (active_object,)
+        self.__selected_objects = tuple(set(selected_objects) | {active_object}) if selected_objects else (active_object,)
 
         self.__hides: List[bool] = []
         for i in self.__selected_objects:

--- a/mmd_tools/core/bone.py
+++ b/mmd_tools/core/bone.py
@@ -326,10 +326,7 @@ class FnBone:
 
     @staticmethod
     def apply_auto_bone_roll(armature):
-        bone_names = []
-        for b in armature.pose.bones:
-            if not b.is_mmd_shadow_bone and not b.mmd_bone.enabled_local_axes and FnBone.has_auto_local_axis(b.mmd_bone.name_j):
-                bone_names.append(b.name)
+        bone_names = [b.name for b in armature.pose.bones if not b.is_mmd_shadow_bone and not b.mmd_bone.enabled_local_axes and FnBone.has_auto_local_axis(b.mmd_bone.name_j)]
         with bpyutils.edit_object(armature) as data:
             bone: bpy.types.EditBone
             for bone in data.edit_bones:

--- a/mmd_tools/core/bone.py
+++ b/mmd_tools/core/bone.py
@@ -456,6 +456,11 @@ class FnBone:
                 remove_constraint(constraints, name)
                 return
             c = TransformConstraintOp.create(constraints, name, map_type)
+            # FIXME: Some bones require specific rotation modes to match MMD behavior.
+            # Currently using hardcoded bone names as a temporary solution.
+            # See https://github.com/MMD-Blender/blender_mmd_tools/issues/242
+            if bone_name in {"左肩C", "右肩C"}:
+                c.from_rotation_mode = "ZYX"  # Best matches MMD behavior for shoulder bones
             c.target = p_bone.id_data
             shadow_bone.add_constraint(c)
             TransformConstraintOp.update_min_max(c, value, influence)

--- a/mmd_tools/core/bone.py
+++ b/mmd_tools/core/bone.py
@@ -456,7 +456,7 @@ class FnBone:
             # FIXME: Some bones require specific rotation modes to match MMD behavior.
             # Currently using hardcoded bone names as a temporary solution.
             # See https://github.com/MMD-Blender/blender_mmd_tools/issues/242
-            if bone_name in {"左肩C", "右肩C"}:
+            if bone_name in {"左肩C", "右肩C", "肩C.L", "肩C.R"}:
                 c.from_rotation_mode = "ZYX"  # Best matches MMD behavior for shoulder bones
             c.target = p_bone.id_data
             shadow_bone.add_constraint(c)

--- a/mmd_tools/core/camera.py
+++ b/mmd_tools/core/camera.py
@@ -185,11 +185,8 @@ class MMDCamera:
         frame_count = frame_end - frame_start
         frames = range(frame_start, frame_end)
 
-        fcurves = []
-        for i in range(3):
-            fcurves.append(parent_action.fcurves.new(data_path="location", index=i))  # x, y, z
-        for i in range(3):
-            fcurves.append(parent_action.fcurves.new(data_path="rotation_euler", index=i))  # rx, ry, rz
+        fcurves = [parent_action.fcurves.new(data_path="location", index=i) for i in range(3)]  # x, y, z
+        fcurves.extend(parent_action.fcurves.new(data_path="rotation_euler", index=i) for i in range(3))  # rx, ry, rz
         fcurves.append(parent_action.fcurves.new(data_path="mmd_camera.angle"))  # fov
         fcurves.append(parent_action.fcurves.new(data_path="mmd_camera.is_perspective"))  # persp
         fcurves.append(distance_action.fcurves.new(data_path="location", index=1))  # dis

--- a/mmd_tools/core/camera.py
+++ b/mmd_tools/core/camera.py
@@ -101,7 +101,7 @@ class MMDCamera:
     def __init__(self, obj):
         root_object = FnCamera.find_root(obj)
         if root_object is None:
-            raise ValueError("%s is not MMDCamera" % str(obj))
+            raise ValueError(f"{str(obj)} is not MMDCamera")
 
         self.__emptyObj = getattr(root_object, "original", obj)
 

--- a/mmd_tools/core/lamp.py
+++ b/mmd_tools/core/lamp.py
@@ -13,7 +13,7 @@ class MMDLamp:
         if obj and obj.type == "EMPTY" and obj.mmd_type == "LIGHT":
             self.__emptyObj = obj
         else:
-            raise ValueError("%s is not MMDLamp" % str(obj))
+            raise ValueError(f"{str(obj)} is not MMDLamp")
 
     @staticmethod
     def isLamp(obj):

--- a/mmd_tools/core/material.py
+++ b/mmd_tools/core/material.py
@@ -550,7 +550,7 @@ class FnMaterial:
             links.new(node_shader.outputs["Shader"], node_output.inputs["Surface"])
 
         for name_id in ("Base", "Toon", "Sphere"):
-            texture = self.__get_texture_node("mmd_%s_tex" % name_id.lower())
+            texture = self.__get_texture_node(f"mmd_{name_id.lower()}_tex")
             if texture:
                 name_tex_in, name_alpha_in, name_uv_out = (name_id + x for x in (" Tex", " Alpha", " UV"))
                 if not node_shader.inputs.get(name_tex_in, _Dummy).is_linked:

--- a/mmd_tools/core/material.py
+++ b/mmd_tools/core/material.py
@@ -90,7 +90,7 @@ class FnMaterial:
             # Try to find the materials
             mat1 = mesh.materials[mat1_ref]
             mat2 = mesh.materials[mat2_ref]
-            if None in (mat1, mat2):
+            if None in {mat1, mat2}:
                 raise MaterialNotFoundError
         except (KeyError, IndexError) as exc:
             # Wrap exceptions within our custom ones
@@ -250,7 +250,7 @@ class FnMaterial:
         sphere_texture_type = int(self.material.mmd_material.sphere_texture_type)
         is_sph_add = sphere_texture_type == 2
 
-        if sphere_texture_type not in (1, 2, 3):
+        if sphere_texture_type not in {1, 2, 3}:
             self.__update_shader_input("Sphere Tex Fac", 0)
         else:
             self.__update_shader_input("Sphere Tex Fac", 1)

--- a/mmd_tools/core/material.py
+++ b/mmd_tools/core/material.py
@@ -85,7 +85,7 @@ class FnMaterial:
         Raises:
             MaterialNotFoundError: If one of the materials is not found
         """
-        mesh = cast(bpy.types.Mesh, mesh_object.data)
+        mesh = cast("bpy.types.Mesh", mesh_object.data)
         try:
             # Try to find the materials
             mat1 = mesh.materials[mat1_ref]
@@ -112,7 +112,7 @@ class FnMaterial:
     @staticmethod
     def fixMaterialOrder(meshObj: bpy.types.Object, material_names: Iterable[str]):
         """Fix the material order which is lost after joining meshes."""
-        materials = cast(bpy.types.Mesh, meshObj.data).materials
+        materials = cast("bpy.types.Mesh", meshObj.data).materials
         for new_idx, mat in enumerate(material_names):
             # Get the material that is currently on this index
             other_mat = materials[new_idx]

--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -396,7 +396,7 @@ class FnModel:
             return
 
         # Create new bone order array
-        new_bone_order = valid_bones[:]
+        new_bone_order = valid_bones.copy()
 
         if old_pos < new_pos:
             # Move right: shift left bones to the right by one position

--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -1125,7 +1125,7 @@ class Model:
         if mesh_name == "":
             return None
         for mesh in self.meshes():
-            if mesh_name in (mesh.name, mesh.data.name):
+            if mesh_name in {mesh.name, mesh.data.name}:
                 return mesh
         return None
 
@@ -1143,7 +1143,7 @@ class Model:
         if mesh_name == "":
             return -1
         for i, mesh in enumerate(self.meshes()):
-            if mesh_name in (mesh.name, mesh.data.name):
+            if mesh_name in {mesh.name, mesh.data.name}:
                 return i
         return -1
 
@@ -1225,7 +1225,7 @@ class Model:
             if rigid_type == rigid_body.MODE_STATIC:
                 i.parent_type = "OBJECT"
                 i.parent = self.rigidGroupObject()
-            elif rigid_type in [rigid_body.MODE_DYNAMIC, rigid_body.MODE_DYNAMIC_BONE]:
+            elif rigid_type in {rigid_body.MODE_DYNAMIC, rigid_body.MODE_DYNAMIC_BONE}:
                 arm = relation.target
                 bone_name = relation.subtarget
                 if arm is not None and bone_name != "":
@@ -1283,7 +1283,7 @@ class Model:
             relation = i.constraints["mmd_tools_rigid_parent"]
             relation.mute = True
             # mute IK
-            if int(i.mmd_rigid.type) in [rigid_body.MODE_DYNAMIC, rigid_body.MODE_DYNAMIC_BONE]:
+            if int(i.mmd_rigid.type) in {rigid_body.MODE_DYNAMIC, rigid_body.MODE_DYNAMIC_BONE}:
                 arm = relation.target
                 bone_name = relation.subtarget
                 if arm is not None and bone_name != "":
@@ -1387,7 +1387,7 @@ class Model:
                         fake_child.location = t
                         fake_child.rotation_euler = r.to_euler(fake_child.rotation_mode)
 
-            elif rigid_type in [rigid_body.MODE_DYNAMIC, rigid_body.MODE_DYNAMIC_BONE]:
+            elif rigid_type in {rigid_body.MODE_DYNAMIC, rigid_body.MODE_DYNAMIC_BONE}:
                 m = target_bone.matrix @ target_bone.bone.matrix_local.inverted()
                 self.__rigid_body_matrix_map[rigid_obj] = m
                 t, r, s = (m @ rigid_obj.matrix_local).decompose()

--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -1258,7 +1258,7 @@ class Model:
 
     def __restoreTransforms(self, obj):
         for attr in ("location", "rotation_euler"):
-            attr_name = "__backup_%s__" % attr
+            attr_name = f"__backup_{attr}__"
             val = obj.get(attr_name, None)
             if val is not None:
                 setattr(obj, attr, val)
@@ -1266,7 +1266,7 @@ class Model:
 
     def __backupTransforms(self, obj):
         for attr in ("location", "rotation_euler"):
-            attr_name = "__backup_%s__" % attr
+            attr_name = f"__backup_{attr}__"
             if attr_name in obj:  # should not happen in normal build/clean cycle
                 continue
             obj[attr_name] = getattr(obj, attr, None)

--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -209,7 +209,7 @@ class FnModel:
     def iterate_materials(root_object: Optional[bpy.types.Object]) -> Iterator[bpy.types.Material]:
         if root_object is None:
             return iter(())
-        return (material for mesh_object in FnModel.iterate_mesh_objects(root_object) for material in cast(bpy.types.Mesh, mesh_object.data).materials if material is not None)
+        return (material for mesh_object in FnModel.iterate_mesh_objects(root_object) for material in cast("bpy.types.Mesh", mesh_object.data).materials if material is not None)
 
     @staticmethod
     def iterate_unique_materials(root_object: Optional[bpy.types.Object]) -> Iterator[bpy.types.Material]:
@@ -722,9 +722,9 @@ class FnModel:
             if m.type != "ARMATURE":
                 continue
             # already has armature modifier.
-            return cast(bpy.types.ArmatureModifier, m)
+            return cast("bpy.types.ArmatureModifier", m)
 
-        modifier = cast(bpy.types.ArmatureModifier, mesh_object.modifiers.new(name="Armature", type="ARMATURE"))
+        modifier = cast("bpy.types.ArmatureModifier", mesh_object.modifiers.new(name="Armature", type="ARMATURE"))
         modifier.object = armature_object
         modifier.use_vertex_groups = True
         modifier.name = "mmd_armature"
@@ -790,7 +790,7 @@ class FnModel:
 
         armature_object = FnModel.find_armature_object(root_object)
         for pose_bone in armature_object.pose.bones:
-            for constraint in (cast(bpy.types.KinematicConstraint, c) for c in pose_bone.constraints if c.type == "IK"):
+            for constraint in (cast("bpy.types.KinematicConstraint", c) for c in pose_bone.constraints if c.type == "IK"):
                 iterations = int(constraint.iterations * new_ik_loop_factor / old_ik_loop_factor)
                 logging.info("Update %s of %s: %d -> %d", constraint.name, pose_bone.name, constraint.iterations, iterations)
                 constraint.iterations = iterations

--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -1125,7 +1125,7 @@ class Model:
         if mesh_name == "":
             return None
         for mesh in self.meshes():
-            if mesh.name == mesh_name or mesh.data.name == mesh_name:
+            if mesh_name in (mesh.name, mesh.data.name):
                 return mesh
         return None
 
@@ -1143,7 +1143,7 @@ class Model:
         if mesh_name == "":
             return -1
         for i, mesh in enumerate(self.meshes()):
-            if mesh.name == mesh_name or mesh.data.name == mesh_name:
+            if mesh_name in (mesh.name, mesh.data.name):
                 return i
         return -1
 

--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -574,8 +574,8 @@ class FnModel:
                         # Execute the join - after merging, objects will remain at the parent armature's position
                         bpy.ops.object.join()
 
-                    except Exception as e:
-                        logging.error(f"Error joining armatures: {e}")
+                    except Exception:
+                        logging.exception("Error joining armatures")
                         # Ensure we exit special modes regardless of what happened
                         if bpy.context.mode != "OBJECT":
                             bpy.ops.object.mode_set(mode="OBJECT")
@@ -634,8 +634,8 @@ class FnModel:
                     try:
                         if child_rigid_group_object.name in bpy.data.objects:
                             bpy.data.objects.remove(child_rigid_group_object)
-                    except Exception as e:
-                        logging.error(f"Error removing rigid group: {e}")
+                    except Exception:
+                        logging.exception("Error removing rigid group")
 
             # Handle joints - similar to the rigid body approach
             child_joint_group_object = FnModel.find_joint_group_object(child_root_object)
@@ -667,8 +667,8 @@ class FnModel:
                     try:
                         if child_joint_group_object.name in bpy.data.objects:
                             bpy.data.objects.remove(child_joint_group_object)
-                    except Exception as e:
-                        logging.error(f"Error removing joint group: {e}")
+                    except Exception:
+                        logging.exception("Error removing joint group")
 
             # Handle temporary objects - similar approach
             child_temporary_group_object = FnModel.find_temporary_group_object(child_root_object)
@@ -707,22 +707,22 @@ class FnModel:
 
                         if child_temporary_group_object.name in bpy.data.objects:
                             bpy.data.objects.remove(child_temporary_group_object)
-                    except Exception as e:
-                        logging.error(f"Error removing temporary objects: {e}")
+                    except Exception:
+                        logging.exception("Error removing temporary objects")
 
             # Copy MMD root properties
             try:
                 FnModel.copy_mmd_root(parent_root_object, child_root_object, overwrite=False)
-            except Exception as e:
-                logging.error(f"Error copying MMD root: {e}")
+            except Exception:
+                logging.exception("Error copying MMD root")
 
             # Safely remove empty child root objects
             try:
                 if child_root_object and len(child_root_object.children) == 0:
                     if child_root_object.name in bpy.data.objects:
                         bpy.data.objects.remove(child_root_object)
-            except Exception as e:
-                logging.error(f"Error removing child root object: {e}")
+            except Exception:
+                logging.exception("Error removing child root object")
 
         # Clean and reapply additional transformations to properly set up all bones and constraints
         bpy.ops.mmd_tools.clean_additional_transform()

--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -609,10 +609,7 @@ class FnModel:
                 parent_rigid_group_object = FnModel.find_rigid_group_object(parent_root_object)
                 if parent_rigid_group_object and parent_rigid_group_object.name in bpy.context.view_layer.objects.keys():
                     # Safely handle each rigid body
-                    rigid_objects = []
-                    for obj in FnModel.iterate_rigid_body_objects(child_root_object):
-                        if obj.name in bpy.context.view_layer.objects.keys():
-                            rigid_objects.append(obj)
+                    rigid_objects = [obj for obj in FnModel.iterate_rigid_body_objects(child_root_object) if obj.name in bpy.context.view_layer.objects.keys()]
 
                     if rigid_objects:
                         # Ensure we're in object mode
@@ -642,10 +639,7 @@ class FnModel:
             if child_joint_group_object and child_joint_group_object.name in bpy.context.view_layer.objects.keys():
                 parent_joint_group_object = FnModel.find_joint_group_object(parent_root_object)
                 if parent_joint_group_object and parent_joint_group_object.name in bpy.context.view_layer.objects.keys():
-                    joint_objects = []
-                    for obj in FnModel.iterate_joint_objects(child_root_object):
-                        if obj.name in bpy.context.view_layer.objects.keys():
-                            joint_objects.append(obj)
+                    joint_objects = [obj for obj in FnModel.iterate_joint_objects(child_root_object) if obj.name in bpy.context.view_layer.objects.keys()]
 
                     if joint_objects:
                         # Ensure we're in object mode
@@ -675,10 +669,7 @@ class FnModel:
             if child_temporary_group_object and child_temporary_group_object.name in bpy.context.view_layer.objects.keys():
                 parent_temporary_group_object = FnModel.find_temporary_group_object(parent_root_object)
                 if parent_temporary_group_object and parent_temporary_group_object.name in bpy.context.view_layer.objects.keys():
-                    temp_objects = []
-                    for obj in FnModel.iterate_temporary_objects(child_root_object):
-                        if obj.name in bpy.context.view_layer.objects.keys():
-                            temp_objects.append(obj)
+                    temp_objects = [obj for obj in FnModel.iterate_temporary_objects(child_root_object) if obj.name in bpy.context.view_layer.objects.keys()]
 
                     if temp_objects:
                         # Ensure we're in object mode
@@ -698,10 +689,7 @@ class FnModel:
 
                     # Safely remove child objects and groups
                     try:
-                        child_objects = []
-                        for obj in FnModel.iterate_child_objects(child_temporary_group_object):
-                            if obj.name in bpy.data.objects:
-                                child_objects.append(obj)
+                        child_objects = [obj for obj in FnModel.iterate_child_objects(child_temporary_group_object) if obj.name in bpy.data.objects]
                         for obj in child_objects:
                             bpy.data.objects.remove(obj)
 

--- a/mmd_tools/core/morph.py
+++ b/mmd_tools/core/morph.py
@@ -243,7 +243,7 @@ class FnMorph:
         for idx, offset in offset_map.items():
             for val, axis in zip(offset, "XYZW", strict=False):
                 if abs(val) > 1e-4:
-                    vg_name = "UV_{0}{1}{2}".format(morph_name, "-" if val < 0 else "+", axis)
+                    vg_name = f"UV_{morph_name}{'-' if val < 0 else '+'}{axis}"
                     vg = vertex_groups.get(vg_name, None) or vertex_groups.new(name=vg_name)
                     vg.add(index=[idx], weight=abs(val) / scale, type="REPLACE")
 

--- a/mmd_tools/core/morph.py
+++ b/mmd_tools/core/morph.py
@@ -422,7 +422,7 @@ class _MorphSlider:
         morph_sliders = self.placeholder()
         morph_sliders = morph_sliders.data.shape_keys.key_blocks if morph_sliders else {}
         for mesh_object in rig.meshes():
-            for kb in getattr(mesh_object.data.shape_keys, "key_blocks", cast(Tuple[bpy.types.ShapeKey], ())):
+            for kb in getattr(mesh_object.data.shape_keys, "key_blocks", cast("Tuple[bpy.types.ShapeKey]", ())):
                 if kb.name in names_in_use:
                     continue
 

--- a/mmd_tools/core/pmd/__init__.py
+++ b/mmd_tools/core/pmd/__init__.py
@@ -7,8 +7,6 @@ import os
 import re
 import struct
 
-from ..vmd import _decodeCp932String
-
 
 class InvalidFileError(Exception):
     pass
@@ -71,10 +69,16 @@ class FileReadStream(FileStream):
         return v
 
     def readStr(self, size):
+        r"""Read a string of given byte size from file, decode it as cp932.
+        Example:
+            original = "あ"
+            buf = b"\x82\xa0\x00\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd"
+            result = "あ"
+        """
         buf = self.__fin.read(size)
-        if not buf:
+        if buf[0] == b"\xfd":
             return ""
-        return _decodeCp932String(buf)
+        return buf.split(b"\x00")[0].decode("cp932", errors="replace")
 
     def readFloat(self):
         (v,) = struct.unpack("<f", self.__fin.read(4))

--- a/mmd_tools/core/pmd/__init__.py
+++ b/mmd_tools/core/pmd/__init__.py
@@ -617,8 +617,8 @@ def load(path):
         model = Model()
         try:
             model.load(fs)
-        except struct.error as e:
-            logging.error(" * Corrupted file: %s", e)
+        except struct.error:
+            logging.exception(" * Corrupted file")
             # raise
 
         logging.info(" Finish loading.")

--- a/mmd_tools/core/pmd/importer.py
+++ b/mmd_tools/core/pmd/importer.py
@@ -248,9 +248,7 @@ def import_pmd_to_pmx(filepath):
     else:
         if len(t) > 1:
             logging.warning("Found two or more base morphs.")
-        vertex_map = []
-        for i in t[0].data:
-            vertex_map.append(i.index)
+        vertex_map = [i.index for i in t[0].data]
 
         for morph in pmd_model.morphs:
             logging.debug("Vertex Morph: %s", morph.name)

--- a/mmd_tools/core/pmd/importer.py
+++ b/mmd_tools/core/pmd/importer.py
@@ -93,7 +93,7 @@ def import_pmd_to_pmx(filepath):
         pmx_bone.name_e = bone.name_e
         pmx_bone.location = bone.position
         pmx_bone.parent = bone.parent
-        if bone.type != 9 and bone.type != 8 and bone.tail_bone > 0:
+        if bone.type not in {9, 8} and bone.tail_bone > 0:
             pmx_bone.displayConnection = bone.tail_bone  # Corresponds to 'BONE' type
         else:
             pmx_bone.displayConnection = -1  # Corresponds to 'NONE' type

--- a/mmd_tools/core/pmd/importer.py
+++ b/mmd_tools/core/pmd/importer.py
@@ -134,7 +134,7 @@ def import_pmd_to_pmx(filepath):
 
         pmx_model.bones.append(pmx_bone)
 
-        if re.search("ひざ$", pmx_bone.name):
+        if re.search(r"ひざ$", pmx_bone.name):
             knee_bones.append(i)
 
     for i in pmx_model.bones:

--- a/mmd_tools/core/pmx/__init__.py
+++ b/mmd_tools/core/pmx/__init__.py
@@ -991,7 +991,7 @@ class Bone:
     def __repr__(self):
         return "<Bone name %s, name_e %s>" % (
             self.name,
-            self.name_e,)
+            self.name_e)
 
     def load(self, fs):
         self.name = fs.readStr()

--- a/mmd_tools/core/pmx/__init__.py
+++ b/mmd_tools/core/pmx/__init__.py
@@ -1619,12 +1619,14 @@ def load(path):
         header = Header()
         header.load(fs)
         fs.setHeader(header)
+
         model = Model()
         try:
             model.load(fs)
-        except struct.error as e:
-            logging.error(" * Corrupted file: %s", e)
+        except struct.error:
+            logging.exception(" * Corrupted file")
             # raise
+
         logging.info(" Finished loading.")
         logging.info("----------------------------------------")
         logging.info(" mmd_tools.pmx module")

--- a/mmd_tools/core/pmx/__init__.py
+++ b/mmd_tools/core/pmx/__init__.py
@@ -54,7 +54,7 @@ class FileReadStream(FileStream):
         if size in typedict:
             index, = struct.unpack(typedict[size], self.__fin.read(size))
         else:
-            raise ValueError("invalid data size %s" % str(size))
+            raise ValueError(f"invalid data size {str(size)}")
         return index
 
     def __readSignedIndex(self, size):
@@ -128,7 +128,7 @@ class FileWriteStream(FileStream):
         if size in typedict:
             self.__fout.write(struct.pack(typedict[size], int(index)))
         else:
-            raise ValueError("invalid data size %s" % str(size))
+            raise ValueError(f"invalid data size {str(size)}")
 
     def __writeSignedIndex(self, index, size):
         return self.__writeIndex(index, size, {1: "<b", 2: "<h", 4: "<i"})
@@ -198,7 +198,7 @@ class Encoding:
         if isinstance(arg, str):
             t = list(filter(lambda x: x[1] == arg, self._MAP))
             if len(t) == 0:
-                raise ValueError("invalid charset %s" % arg)
+                raise ValueError(f"invalid charset {arg}")
         elif isinstance(arg, int):
             t = list(filter(lambda x: x[0] == arg, self._MAP))
             if len(t) == 0:
@@ -210,7 +210,7 @@ class Encoding:
         self.charset  = t[1]
 
     def __repr__(self):
-        return "<Encoding charset %s>" % self.charset
+        return f"<Encoding charset {self.charset}>"
 
 
 class Coordinate:
@@ -270,7 +270,7 @@ class Header:
         logging.debug("pmx format version: %f", self.version)
         if self.version != self.VERSION:
             logging.error("PMX version %.1f is unsupported", self.version)
-            raise UnsupportedVersionError("unsupported PMX version: %.1f" % self.version)
+            raise UnsupportedVersionError(f"unsupported PMX version: {self.version:.1f}")
         if fs.readByte() != 8:
             logging.warning(" * This file might be corrupted.")
         self.encoding = Encoding(fs.readByte())
@@ -641,13 +641,7 @@ comment(english):
         logging.info("finished exporting the model.")
 
     def __repr__(self):
-        return "<Model name %s, name_e %s, comment %s, comment_e %s, textures %s>" % (
-            self.name,
-            self.name_e,
-            self.comment,
-            self.comment_e,
-            str(self.textures),
-            )
+        return f"<Model name {self.name}, name_e {self.name_e}, comment {self.comment}, comment_e {self.comment_e}, textures {str(self.textures)}>"
 
 
 class Vertex:
@@ -660,14 +654,7 @@ class Vertex:
         self.edge_scale = 1
 
     def __repr__(self):
-        return "<Vertex co %s, normal %s, uv %s, additional_uvs %s, weight %s, edge_scale %s>" % (
-            str(self.co),
-            str(self.normal),
-            str(self.uv),
-            str(self.additional_uvs),
-            str(self.weight),
-            str(self.edge_scale),
-            )
+        return f"<Vertex co {str(self.co)}, normal {str(self.normal)}, uv {str(self.uv)}, additional_uvs {str(self.additional_uvs)}, weight {str(self.weight)}, edge_scale {str(self.edge_scale)}>"
 
     def load(self, fs):
         self.co = fs.readVector(3)
@@ -756,7 +743,7 @@ class BoneWeight:
             self.weights.r0 = fs.readVector(3)
             self.weights.r1 = fs.readVector(3)
         else:
-            raise ValueError("invalid weight type %s" % str(self.type))
+            raise ValueError(f"invalid weight type {str(self.type)}")
 
     def save(self, fs):
         fs.writeByte(self.type)
@@ -781,7 +768,7 @@ class BoneWeight:
             fs.writeVector(self.weights.r0)
             fs.writeVector(self.weights.r1)
         else:
-            raise ValueError("invalid weight type %s" % str(self.type))
+            raise ValueError(f"invalid weight type {str(self.type)}")
 
 
 class Texture:
@@ -789,7 +776,7 @@ class Texture:
         self.path = ""
 
     def __repr__(self):
-        return "<Texture path %s>" % str(self.path)
+        return f"<Texture path {str(self.path)}>"
 
     def load(self, fs):
         self.path = fs.readStr()
@@ -847,25 +834,7 @@ class Material:
         self.vertex_count = 0
 
     def __repr__(self):
-        return "<Material name %s, name_e %s, diffuse %s, specular %s, shininess %s, ambient %s, is_double_sided %s, enabled_drop_shadow %s, enabled_self_shadow_map %s, enabled_self_shadow %s, enabled_toon_edge %s, edge_color %s, edge_size %s, texture %s, sphere_texture %s, toon_texture %s, comment %s>" % (
-            self.name,
-            self.name_e,
-            str(self.diffuse),
-            str(self.specular),
-            str(self.shininess),
-            str(self.ambient),
-            str(self.is_double_sided),
-            str(self.enabled_drop_shadow),
-            str(self.enabled_self_shadow_map),
-            str(self.enabled_self_shadow),
-            str(self.enabled_toon_edge),
-            str(self.edge_color),
-            str(self.edge_size),
-            str(self.texture),
-            str(self.sphere_texture),
-            str(self.toon_texture),
-            str(self.comment),
-        )
+        return f"<Material name {self.name}, name_e {self.name_e}, diffuse {str(self.diffuse)}, specular {str(self.specular)}, shininess {str(self.shininess)}, ambient {str(self.ambient)}, is_double_sided {str(self.is_double_sided)}, enabled_drop_shadow {str(self.enabled_drop_shadow)}, enabled_self_shadow_map {str(self.enabled_self_shadow_map)}, enabled_self_shadow {str(self.enabled_self_shadow)}, enabled_toon_edge {str(self.enabled_toon_edge)}, edge_color {str(self.edge_color)}, edge_size {str(self.edge_size)}, texture {str(self.texture)}, sphere_texture {str(self.sphere_texture)}, toon_texture {str(self.toon_texture)}, comment {str(self.comment)}>"
 
     def load(self, fs, num_textures):
         def __tex_index(index):
@@ -989,9 +958,7 @@ class Bone:
         self.ik_links = []
 
     def __repr__(self):
-        return "<Bone name %s, name_e %s>" % (
-            self.name,
-            self.name_e)
+        return f"<Bone name {self.name}, name_e {self.name_e}>"
 
     def load(self, fs):
         self.name = fs.readStr()
@@ -1116,7 +1083,7 @@ class IKLink:
         self.minimumAngle = None
 
     def __repr__(self):
-        return "<IKLink target %s>" % (str(self.target))
+        return f"<IKLink target {str(self.target)}>"
 
     def load(self, fs):
         self.target = fs.readBoneIndex()
@@ -1152,7 +1119,7 @@ class Morph:
         self.category = category
 
     def __repr__(self):
-        return "<Morph name %s, name_e %s>" % (self.name, self.name_e)
+        return f"<Morph name {self.name}, name_e {self.name_e}>"
 
     def type_index(self):
         raise NotImplementedError
@@ -1389,10 +1356,7 @@ class Display:
         self.data = []
 
     def __repr__(self):
-        return "<Display name %s, name_e %s>" % (
-            self.name,
-            self.name_e,
-            )
+        return f"<Display name {self.name}, name_e {self.name_e}>"
 
     def load(self, fs):
         self.name = fs.readStr()
@@ -1461,10 +1425,7 @@ class Rigid:
         self.mode = 0
 
     def __repr__(self):
-        return "<Rigid name %s, name_e %s>" % (
-            self.name,
-            self.name_e,
-            )
+        return f"<Rigid name {self.name}, name_e {self.name_e}>"
 
     def load(self, fs):
         self.name = fs.readStr()

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -601,7 +601,7 @@ class __PmxExporter:
             for vtx_morph in root.mmd_root.vertex_morphs:
                 morph_english_names[vtx_morph.name] = vtx_morph.name_e
                 morph_categories[vtx_morph.name] = categories.get(vtx_morph.category, pmx.Morph.CATEGORY_OHTER)
-            shape_key_names.sort(key=lambda x: root.mmd_root.vertex_morphs.find(x))
+            shape_key_names.sort(key=root.mmd_root.vertex_morphs.find)
 
         for i in shape_key_names:
             morph = pmx.VertexMorph(name=i, name_e=morph_english_names.get(i, ""), category=morph_categories.get(i, pmx.Morph.CATEGORY_OHTER))

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -1072,8 +1072,7 @@ class __PmxExporter:
         bm_temp.from_mesh(base_mesh)
         loop_angles = []
         for face in bm_temp.faces:
-            for loop in face.loops:
-                loop_angles.append(loop.calc_angle())
+            loop_angles.extend(loop.calc_angle() for loop in face.loops)
         bm_temp.free()
         # Apply transformation to triangulated mesh
         base_mesh.transform(pmx_matrix)

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -1111,7 +1111,7 @@ class __PmxExporter:
                     get_edge_scale(v),
                     get_vertex_order(v),
                     get_uv_offsets(v),
-                )
+                ),
             ]
 
         # Extract vertex colors as ADD UV2

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -813,7 +813,7 @@ class __PmxExporter:
                 if j.type == "BONE" and j.name in bone_map:
                     items.append((0, bone_map[j.name]))
                 elif j.type == "MORPH" and (j.morph_type, j.name) in morph_map:
-                    items.append((1, morph_map[(j.morph_type, j.name)]))
+                    items.append((1, morph_map[j.morph_type, j.name]))
                 else:
                     logging.warning("Display item (%s, %s) was not found.", j.type, j.name)
             d.data = items

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -1063,8 +1063,8 @@ class __PmxExporter:
         normal_matrix = pmx_matrix.to_3x3()
         if not (sx == sy == sz):
             invert_scale_matrix = Matrix([[1.0 / sx, 0, 0], [0, 1.0 / sy, 0], [0, 0, 1.0 / sz]])
-            normal_matrix = normal_matrix @ invert_scale_matrix  # reset the scale of meshObj.matrix_world
-            normal_matrix = normal_matrix @ invert_scale_matrix  # the scale transform of normals
+            normal_matrix @= invert_scale_matrix  # reset the scale of meshObj.matrix_world
+            normal_matrix @= invert_scale_matrix  # the scale transform of normals
 
         # Extract normals and angles before apply transformation
         loop_normals = self.__get_normals(base_mesh, normal_matrix)

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -1040,14 +1040,14 @@ class __PmxExporter:
         total_weight = sum(weights) or 1.0  # Avoid division by zero
 
         # Average normals
-        if len(set(tuple(n) for n in v._normal_list)) == 1:  # All normals identical
+        if len({tuple(n) for n in v._normal_list}) == 1:  # All normals identical
             v.normal = normal
         else:
             weighted_normal_sum = sum((n * w for n, w in zip(v._normal_list, weights, strict=False)), Vector((0, 0, 0)))
             v.normal = (weighted_normal_sum / total_weight).normalized()
 
         # Average vertex colors and convert to ADD UV2 format
-        if len(set(tuple(c) for c in v._color_list)) == 1:  # All colors identical
+        if len({tuple(c) for c in v._color_list}) == 1:  # All colors identical
             final_color = color_vec
         else:
             weighted_color_sum = sum((c * w for c, w in zip(v._color_list, weights, strict=False)), Vector((0, 0, 0, 0)))

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -1020,6 +1020,7 @@ class __PmxExporter:
         def _to_mesh_clear(obj, mesh):
             return obj.to_mesh_clear()
 
+        # Use try-finally pattern to guarantee temporary modifier cleanup, preventing scene pollution
         base_mesh = None
         temp_tri_mod = None
         try:

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -1407,12 +1407,12 @@ class __PmxExporter:
 
 def export(filepath, **kwargs):
     logging.info("****************************************")
-    logging.info(" %s module" % __name__)
+    logging.info(" %s module", __name__)
     logging.info("----------------------------------------")
     start_time = time.time()
     exporter = __PmxExporter()
     exporter.execute(filepath, **kwargs)
     logging.info(" Finished exporting the model in %f seconds.", time.time() - start_time)
     logging.info("----------------------------------------")
-    logging.info(" %s module" % __name__)
+    logging.info(" %s module", __name__)
     logging.info("****************************************")

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -273,9 +273,7 @@ class PMXImporter:
         return nameTable, specialTipBones
 
     def __sortPoseBonesByBoneIndex(self, pose_bones: List[bpy.types.PoseBone], bone_names):
-        r: List[bpy.types.PoseBone] = []
-        for i in bone_names:
-            r.append(pose_bones[i])
+        r: List[bpy.types.PoseBone] = [pose_bones[i] for i in bone_names]
         return r
 
     @staticmethod

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -260,7 +260,7 @@ class PMXImporter:
                             b_bone.tail = b_bone.head + Vector((0, 0, 1)) * self.__scale
                     else:
                         b_bone.tail = b_bone.head + Vector((0, 0, 1)) * self.__scale
-                    if m_bone.displayConnection != -1 and m_bone.displayConnection != [0.0, 0.0, 0.0]:
+                    if m_bone.displayConnection not in (-1, (0.0, 0.0, 0.0), [0.0, 0.0, 0.0]):
                         logging.debug(" * special tip bone %s, display %s", b_bone.name, str(m_bone.displayConnection))
                         specialTipBones.append(b_bone.name)
 
@@ -421,7 +421,7 @@ class PMXImporter:
             else:  # vector offset
                 mmd_bone.display_connection_type = "OFFSET"
 
-            if pmx_bone.displayConnection == -1 or pmx_bone.displayConnection == (0.0, 0.0, 0.0):
+            if pmx_bone.displayConnection in (-1, (0.0, 0.0, 0.0), [0.0, 0.0, 0.0]):
                 mmd_bone.is_tip = True
             elif b_bone.name in specialTipBones:
                 mmd_bone.is_tip = True

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -990,7 +990,7 @@ class _PMXCleaner:
         pmx_vertices = pmx_model.vertices
 
         # clean face/vertex
-        cls.__clean_pmx_faces(pmx_faces, pmx_model.materials, lambda f: frozenset(f))
+        cls.__clean_pmx_faces(pmx_faces, pmx_model.materials, frozenset)
 
         index_map = {v: v for f in pmx_faces for v in f}
         is_index_clean = len(index_map) == len(pmx_vertices)

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -238,7 +238,7 @@ class PMXImporter:
                     b_target = editBoneTable[m_bone.target]
                     for i in range(len(m_bone.ik_links)):
                         b_bone_link = editBoneTable[m_bone.ik_links[i].target]
-                        if self.__fix_IK_links or b_bone_link.length < 0.001:
+                        if self.__fix_ik_links or b_bone_link.length < 0.001:
                             b_bone_tail = b_target if i == 0 else editBoneTable[m_bone.ik_links[i - 1].target]
                             loc = b_bone_tail.head - b_bone_link.head
                             if loc.length < 0.001:
@@ -908,7 +908,7 @@ class PMXImporter:
         self.__use_mipmap = args.get("use_mipmap", True)
         self.__sph_blend_factor = args.get("sph_blend_factor", 1.0)
         self.__spa_blend_factor = args.get("spa_blend_factor", 1.0)
-        self.__fix_IK_links = args.get("fix_IK_links", False)
+        self.__fix_ik_links = args.get("fix_ik_links", False)
         self.__apply_bone_fixed_axis = args.get("apply_bone_fixed_axis", False)
         self.__translator = args.get("translator")
 

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -616,7 +616,7 @@ class PMXImporter:
                 bf.image = self.__imageTable.get(mi, None)
 
         # Import ADD UV2 as vertex colors
-        if pmxModel.header and pmxModel.header.additional_uvs >= 2:
+        if self.__import_adduv2_as_vertex_colors and pmxModel.header and pmxModel.header.additional_uvs >= 2:
             # Create vertex color layer
             vertex_colors = mesh.vertex_colors.new(name="Color")
             color_data = []
@@ -905,6 +905,7 @@ class PMXImporter:
         remove_doubles = args.get("remove_doubles", False)
         self.__mark_sharp_edges = args.get("mark_sharp_edges", True)
         self.__sharp_edge_angle = args.get("sharp_edge_angle", math.radians(179.0))
+        self.__import_adduv2_as_vertex_colors = args.get("import_adduv2_as_vertex_colors", False)
         self.__scale = args.get("scale", 1.0)
         self.__use_mipmap = args.get("use_mipmap", True)
         self.__sph_blend_factor = args.get("sph_blend_factor", 1.0)

--- a/mmd_tools/core/sdef.py
+++ b/mmd_tools/core/sdef.py
@@ -290,7 +290,7 @@ class FnSDEF:
             use_skip = False
         mod = obj.modifiers.get("mmd_armature")
         variables = f.driver.variables
-        for name in set(data[i].name for data in cls.g_verts[_hash(obj)].values() for i in range(2)):  # add required bones for dependency graph
+        for name in {data[i].name for data in cls.g_verts[_hash(obj)].values() for i in range(2)}:  # add required bones for dependency graph
             var = variables.new()
             var.type = "TRANSFORMS"
             var.targets[0].id = mod.object
@@ -317,7 +317,7 @@ class FnSDEF:
     @classmethod
     def clear_cache(cls, obj=None, unused_only=False):
         if unused_only:
-            valid_keys = set(_hash(i) for i in bpy.data.objects if i.type == "MESH" and i != obj)
+            valid_keys = {_hash(i) for i in bpy.data.objects if i.type == "MESH" and i != obj}
             for key in cls.g_verts.keys() - valid_keys:
                 del cls.g_verts[key]
             for key in cls.g_shapekey_data.keys() - cls.g_verts.keys():

--- a/mmd_tools/core/sdef.py
+++ b/mmd_tools/core/sdef.py
@@ -110,7 +110,7 @@ class FnSDEF:
                     # preprocessing
                     w0, w1 = bgs[0].weight, bgs[1].weight
                     # w0 + w1 == 1
-                    w0 = w0 / (w0 + w1)
+                    w0 /= (w0 + w1)
                     w1 = 1 - w0
 
                     c, r0, r1 = sdef_c[i].co, sdef_r0[i].co, sdef_r1[i].co

--- a/mmd_tools/core/sdef.py
+++ b/mmd_tools/core/sdef.py
@@ -286,8 +286,6 @@ class FnSDEF:
         ov.type = "SINGLE_PROP"
         ov.targets[0].id = obj
         ov.targets[0].data_path = "name"
-        if not bulk_update and use_skip:  # FIXME: force disable use_skip=True for bulk_update=False on 2.8
-            use_skip = False
         mod = obj.modifiers.get("mmd_armature")
         variables = f.driver.variables
         for name in {data[i].name for data in cls.g_verts[_hash(obj)].values() for i in range(2)}:  # add required bones for dependency graph

--- a/mmd_tools/core/sdef.py
+++ b/mmd_tools/core/sdef.py
@@ -294,8 +294,7 @@ class FnSDEF:
             var.targets[0].id = mod.object
             var.targets[0].bone_target = name
         f.driver.use_self = True
-        param = (bulk_update, use_skip, use_scale)
-        f.driver.expression = "mmd_sdef_driver(self, obj, bulk_update={}, use_skip={}, use_scale={})".format(*param)
+        f.driver.expression = f"mmd_sdef_driver(self, obj, bulk_update={bulk_update}, use_skip={use_skip}, use_scale={use_scale})"
         return True
 
     @classmethod

--- a/mmd_tools/core/shader.py
+++ b/mmd_tools/core/shader.py
@@ -263,8 +263,8 @@ class _MaterialMorph:
             # https://github.com/blender/blender/blob/594f47ecd2d5367ca936cf6fc6ec8168c2b360d0/source/blender/blenkernel/intern/material.c#L1400
             node_mix = ng.new_mix_node("MULTIPLY" if use_mul else "ADD", (pos[0] + 1, pos[1]))
             links.new(node_input.outputs["Fac"], node_mix.inputs["Fac"])
-            ng.new_input_socket("%s1" % id_name + tag, node_mix.inputs["Color1"])
-            ng.new_input_socket("%s2" % id_name + tag, node_mix.inputs["Color2"], socket_type="NodeSocketVector")
+            ng.new_input_socket(f"{id_name}1" + tag, node_mix.inputs["Color1"])
+            ng.new_input_socket(f"{id_name}2" + tag, node_mix.inputs["Color2"], socket_type="NodeSocketVector")
             ng.new_output_socket(id_name + tag, node_mix.outputs["Color"])
             return node_mix
 

--- a/mmd_tools/core/shader.py
+++ b/mmd_tools/core/shader.py
@@ -9,7 +9,7 @@ import bpy
 class _NodeTreeUtils:
     def __init__(self, shader: bpy.types.ShaderNodeTree):
         self.shader = shader
-        self.nodes: bpy.types.bpy_prop_collection[bpy.types.ShaderNode] = shader.nodes  # type: ignore
+        self.nodes: bpy.types.bpy_prop_collection[bpy.types.ShaderNode] = shader.nodes  # type: ignore[assignment]
         self.links = shader.links
 
     def _find_node(self, node_type: str) -> Optional[bpy.types.ShaderNode]:

--- a/mmd_tools/core/shader.py
+++ b/mmd_tools/core/shader.py
@@ -64,13 +64,13 @@ class _NodeGroupUtils(_NodeTreeUtils):
     @property
     def node_input(self) -> bpy.types.NodeGroupInput:
         if not self.__node_input:
-            self.__node_input = cast(bpy.types.NodeGroupInput, self._find_node("NodeGroupInput") or self.new_node("NodeGroupInput", (-2, 0)))
+            self.__node_input = cast("bpy.types.NodeGroupInput", self._find_node("NodeGroupInput") or self.new_node("NodeGroupInput", (-2, 0)))
         return self.__node_input
 
     @property
     def node_output(self) -> bpy.types.NodeGroupOutput:
         if not self.__node_output:
-            self.__node_output = cast(bpy.types.NodeGroupOutput, self._find_node("NodeGroupOutput") or self.new_node("NodeGroupOutput", (2, 0)))
+            self.__node_output = cast("bpy.types.NodeGroupOutput", self._find_node("NodeGroupOutput") or self.new_node("NodeGroupOutput", (2, 0)))
         return self.__node_output
 
     def hide_nodes(self, hide_sockets=True):

--- a/mmd_tools/core/translations.py
+++ b/mmd_tools/core/translations.py
@@ -68,7 +68,7 @@ class MMDDataHandlerABC(ABC):
 
     @classmethod
     def check_data_visible(cls, filter_selected: bool, filter_visible: bool, select: bool, hide: bool) -> bool:
-        return filter_selected and not select or filter_visible and hide
+        return (filter_selected and not select) or (filter_visible and hide)
 
     @classmethod
     def prop_restorable(cls, layout: bpy.types.UILayout, mmd_translation_element: "MMDTranslationElement", prop_name: str, original_value: str, index: int):
@@ -699,7 +699,7 @@ class FnTranslations:
         filter_visible: bool = mmd_translation.filter_visible
 
         def check_blank_name(name_j: str, name_e: str) -> bool:
-            return filter_japanese_blank and name_j or filter_english_blank and name_e
+            return (filter_japanese_blank and name_j) or (filter_english_blank and name_e)
 
         for handler in MMD_DATA_HANDLERS:
             if handler.type_name in mmd_translation.filter_types:

--- a/mmd_tools/core/translations.py
+++ b/mmd_tools/core/translations.py
@@ -115,7 +115,7 @@ class MMDBoneHandler(MMDDataHandlerABC):
             if not any(c.is_visible for c in pose_bone.bone.collections):
                 continue
 
-            mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements.add()
+            mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements.add()
             mmd_translation_element.type = MMDTranslationElementType.BONE.name
             mmd_translation_element.object = armature_object
             mmd_translation_element.data_path = f"pose.bones[{index}]"
@@ -130,7 +130,7 @@ class MMDBoneHandler(MMDDataHandlerABC):
 
     @classmethod
     def update_query(cls, mmd_translation: "MMDTranslation", filter_selected: bool, filter_visible: bool, check_blank_name: Callable[[str, str], bool]):
-        mmd_translation_element: "MMDTranslationElement"
+        mmd_translation_element: MMDTranslationElement
         for index, mmd_translation_element in enumerate(mmd_translation.translation_elements):
             if mmd_translation_element.type != MMDTranslationElementType.BONE.name:
                 continue
@@ -146,7 +146,7 @@ class MMDBoneHandler(MMDDataHandlerABC):
             if mmd_translation.filter_restorable and not cls.is_restorable(mmd_translation_element):
                 continue
 
-            mmd_translation_element_index: "MMDTranslationElementIndex" = mmd_translation.filtered_translation_element_indices.add()
+            mmd_translation_element_index: MMDTranslationElementIndex = mmd_translation.filtered_translation_element_indices.add()
             mmd_translation_element_index.value = index
 
     @classmethod
@@ -170,7 +170,7 @@ class MMDMorphHandler(MMDDataHandlerABC):
 
     @classmethod
     def draw_item(cls, layout: bpy.types.UILayout, mmd_translation_element: "MMDTranslationElement", index: int):
-        morph: "_MorphBase" = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
+        morph: _MorphBase = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
         row = layout.row(align=True)
         row.label(text="", icon="SHAPEKEY_DATA")
         prop_row = row.row()
@@ -185,7 +185,7 @@ class MMDMorphHandler(MMDDataHandlerABC):
     @classmethod
     def collect_data(cls, mmd_translation: "MMDTranslation"):
         root_object: bpy.types.Object = mmd_translation.id_data
-        mmd_root: "MMDRoot" = root_object.mmd_root
+        mmd_root: MMDRoot = root_object.mmd_root
 
         for morphs_name, morphs in {
             "material_morphs": mmd_root.material_morphs,
@@ -194,9 +194,9 @@ class MMDMorphHandler(MMDDataHandlerABC):
             "vertex_morphs": mmd_root.vertex_morphs,
             "group_morphs": mmd_root.group_morphs,
         }.items():
-            morph: "_MorphBase"
+            morph: _MorphBase
             for index, morph in enumerate(morphs):
-                mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements.add()
+                mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements.add()
                 mmd_translation_element.type = MMDTranslationElementType.MORPH.name
                 mmd_translation_element.object = root_object
                 mmd_translation_element.data_path = f"mmd_root.{morphs_name}[{index}]"
@@ -215,24 +215,24 @@ class MMDMorphHandler(MMDDataHandlerABC):
 
     @classmethod
     def update_query(cls, mmd_translation: "MMDTranslation", filter_selected: bool, filter_visible: bool, check_blank_name: Callable[[str, str], bool]):
-        mmd_translation_element: "MMDTranslationElement"
+        mmd_translation_element: MMDTranslationElement
         for index, mmd_translation_element in enumerate(mmd_translation.translation_elements):
             if mmd_translation_element.type != MMDTranslationElementType.MORPH.name:
                 continue
 
-            morph: "_MorphBase" = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
+            morph: _MorphBase = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
             if check_blank_name(morph.name, morph.name_e):
                 continue
 
             if mmd_translation.filter_restorable and not cls.is_restorable(mmd_translation_element):
                 continue
 
-            mmd_translation_element_index: "MMDTranslationElementIndex" = mmd_translation.filtered_translation_element_indices.add()
+            mmd_translation_element_index: MMDTranslationElementIndex = mmd_translation.filtered_translation_element_indices.add()
             mmd_translation_element_index.value = index
 
     @classmethod
     def set_names(cls, mmd_translation_element: "MMDTranslationElement", name: Optional[str], name_j: Optional[str], name_e: Optional[str]):
-        morph: "_MorphBase" = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
+        morph: _MorphBase = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
         if name is not None:
             morph.name = name
         if name_e is not None:
@@ -240,7 +240,7 @@ class MMDMorphHandler(MMDDataHandlerABC):
 
     @classmethod
     def get_names(cls, mmd_translation_element: "MMDTranslationElement") -> Tuple[str, str, str]:
-        morph: "_MorphBase" = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
+        morph: _MorphBase = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
         return (morph.name, "", morph.name_e)
 
 
@@ -277,7 +277,7 @@ class MMDMaterialHandler(MMDDataHandlerABC):
                 if not hasattr(material, "mmd_material"):
                     continue
 
-                mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements.add()
+                mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements.add()
                 mmd_translation_element.type = MMDTranslationElementType.MATERIAL.name
                 mmd_translation_element.object = mesh_object
                 mmd_translation_element.data_path = f"data.materials[{index}]"
@@ -298,7 +298,7 @@ class MMDMaterialHandler(MMDDataHandlerABC):
 
     @classmethod
     def update_query(cls, mmd_translation: "MMDTranslation", filter_selected: bool, filter_visible: bool, check_blank_name: Callable[[str, str], bool]):
-        mmd_translation_element: "MMDTranslationElement"
+        mmd_translation_element: MMDTranslationElement
         for index, mmd_translation_element in enumerate(mmd_translation.translation_elements):
             if mmd_translation_element.type != MMDTranslationElementType.MATERIAL.name:
                 continue
@@ -314,7 +314,7 @@ class MMDMaterialHandler(MMDDataHandlerABC):
             if mmd_translation.filter_restorable and not cls.is_restorable(mmd_translation_element):
                 continue
 
-            mmd_translation_element_index: "MMDTranslationElementIndex" = mmd_translation.filtered_translation_element_indices.add()
+            mmd_translation_element_index: MMDTranslationElementIndex = mmd_translation.filtered_translation_element_indices.add()
             mmd_translation_element_index.value = index
 
     @classmethod
@@ -356,7 +356,7 @@ class MMDDisplayHandler(MMDDataHandlerABC):
         armature_object: bpy.types.Object = FnModel.find_armature_object(mmd_translation.id_data)
         bone_collection: bpy.types.BoneCollection
         for index, bone_collection in enumerate(armature_object.data.collections):
-            mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements.add()
+            mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements.add()
             mmd_translation_element.type = MMDTranslationElementType.DISPLAY.name
             mmd_translation_element.object = armature_object
             mmd_translation_element.data_path = f"data.collections[{index}]"
@@ -377,7 +377,7 @@ class MMDDisplayHandler(MMDDataHandlerABC):
 
     @classmethod
     def update_query(cls, mmd_translation: "MMDTranslation", filter_selected: bool, filter_visible: bool, check_blank_name: Callable[[str, str], bool]):
-        mmd_translation_element: "MMDTranslationElement"
+        mmd_translation_element: MMDTranslationElement
         for index, mmd_translation_element in enumerate(mmd_translation.translation_elements):
             if mmd_translation_element.type != MMDTranslationElementType.DISPLAY.name:
                 continue
@@ -393,7 +393,7 @@ class MMDDisplayHandler(MMDDataHandlerABC):
             if mmd_translation.filter_restorable and not cls.is_restorable(mmd_translation_element):
                 continue
 
-            mmd_translation_element_index: "MMDTranslationElementIndex" = mmd_translation.filtered_translation_element_indices.add()
+            mmd_translation_element_index: MMDTranslationElementIndex = mmd_translation.filtered_translation_element_indices.add()
             mmd_translation_element_index.value = index
 
     @classmethod
@@ -438,7 +438,7 @@ class MMDPhysicsHandler(MMDDataHandlerABC):
 
         obj: bpy.types.Object
         for obj in model.rigidBodies():
-            mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements.add()
+            mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements.add()
             mmd_translation_element.type = MMDTranslationElementType.PHYSICS.name
             mmd_translation_element.object = obj
             mmd_translation_element.data_path = "mmd_rigid"
@@ -448,7 +448,7 @@ class MMDPhysicsHandler(MMDDataHandlerABC):
 
         obj: bpy.types.Object
         for obj in model.joints():
-            mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements.add()
+            mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements.add()
             mmd_translation_element.type = MMDTranslationElementType.PHYSICS.name
             mmd_translation_element.object = obj
             mmd_translation_element.data_path = "mmd_joint"
@@ -462,7 +462,7 @@ class MMDPhysicsHandler(MMDDataHandlerABC):
 
     @classmethod
     def update_query(cls, mmd_translation: "MMDTranslation", filter_selected: bool, filter_visible: bool, check_blank_name: Callable[[str, str], bool]):
-        mmd_translation_element: "MMDTranslationElement"
+        mmd_translation_element: MMDTranslationElement
         for index, mmd_translation_element in enumerate(mmd_translation.translation_elements):
             if mmd_translation_element.type != MMDTranslationElementType.PHYSICS.name:
                 continue
@@ -482,7 +482,7 @@ class MMDPhysicsHandler(MMDDataHandlerABC):
             if mmd_translation.filter_restorable and not cls.is_restorable(mmd_translation_element):
                 continue
 
-            mmd_translation_element_index: "MMDTranslationElementIndex" = mmd_translation.filtered_translation_element_indices.add()
+            mmd_translation_element_index: MMDTranslationElementIndex = mmd_translation.filtered_translation_element_indices.add()
             mmd_translation_element_index.value = index
 
     @classmethod
@@ -543,7 +543,7 @@ class MMDInfoHandler(MMDDataHandlerABC):
             info_objects.append(armature_object)
 
         for info_object in itertools.chain(info_objects, FnModel.iterate_mesh_objects(root_object)):
-            mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements.add()
+            mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements.add()
             mmd_translation_element.type = MMDTranslationElementType.INFO.name
             mmd_translation_element.object = info_object
             mmd_translation_element.data_path = ""
@@ -557,7 +557,7 @@ class MMDInfoHandler(MMDDataHandlerABC):
 
     @classmethod
     def update_query(cls, mmd_translation: "MMDTranslation", filter_selected: bool, filter_visible: bool, check_blank_name: Callable[[str, str], bool]):
-        mmd_translation_element: "MMDTranslationElement"
+        mmd_translation_element: MMDTranslationElement
         for index, mmd_translation_element in enumerate(mmd_translation.translation_elements):
             if mmd_translation_element.type != MMDTranslationElementType.INFO.name:
                 continue
@@ -572,7 +572,7 @@ class MMDInfoHandler(MMDDataHandlerABC):
             if mmd_translation.filter_restorable and not cls.is_restorable(mmd_translation_element):
                 continue
 
-            mmd_translation_element_index: "MMDTranslationElementIndex" = mmd_translation.filtered_translation_element_indices.add()
+            mmd_translation_element_index: MMDTranslationElementIndex = mmd_translation.filtered_translation_element_indices.add()
             mmd_translation_element_index.value = index
 
     @classmethod
@@ -602,10 +602,10 @@ MMD_DATA_TYPE_TO_HANDLERS: Dict[str, MMDDataHandlerABC] = {h.type_name: h for h 
 class FnTranslations:
     @staticmethod
     def apply_translations(root_object: bpy.types.Object):
-        mmd_translation: "MMDTranslation" = root_object.mmd_root.translation
-        mmd_translation_element_index: "MMDTranslationElementIndex"
+        mmd_translation: MMDTranslation = root_object.mmd_root.translation
+        mmd_translation_element_index: MMDTranslationElementIndex
         for mmd_translation_element_index in mmd_translation.filtered_translation_element_indices:
-            mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements[mmd_translation_element_index.value]
+            mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements[mmd_translation_element_index.value]
             handler: MMDDataHandlerABC = MMD_DATA_TYPE_TO_HANDLERS[mmd_translation_element.type]
             name, name_j, name_e = handler.get_names(mmd_translation_element)
             handler.set_names(
@@ -617,7 +617,7 @@ class FnTranslations:
 
     @staticmethod
     def execute_translation_batch(root_object: bpy.types.Object) -> Tuple[Dict[str, str], Optional[bpy.types.Text]]:
-        mmd_translation: "MMDTranslation" = root_object.mmd_root.translation
+        mmd_translation: MMDTranslation = root_object.mmd_root.translation
         batch_operation_script = mmd_translation.batch_operation_script
         if not batch_operation_script:
             return ({}, None)
@@ -632,9 +632,9 @@ class FnTranslations:
         batch_operation_script_ast = compile(mmd_translation.batch_operation_script, "<string>", "eval")
         batch_operation_target: str = mmd_translation.batch_operation_target
 
-        mmd_translation_element_index: "MMDTranslationElementIndex"
+        mmd_translation_element_index: MMDTranslationElementIndex
         for mmd_translation_element_index in mmd_translation.filtered_translation_element_indices:
-            mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements[mmd_translation_element_index.value]
+            mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements[mmd_translation_element_index.value]
 
             handler: MMDDataHandlerABC = MMD_DATA_TYPE_TO_HANDLERS[mmd_translation_element.type]
 
@@ -676,8 +676,8 @@ class FnTranslations:
         if mmd_translation.filtered_translation_element_indices_active_index < 0:
             return
 
-        mmd_translation_element_index: "MMDTranslationElementIndex" = mmd_translation.filtered_translation_element_indices[mmd_translation.filtered_translation_element_indices_active_index]
-        mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements[mmd_translation_element_index.value]
+        mmd_translation_element_index: MMDTranslationElementIndex = mmd_translation.filtered_translation_element_indices[mmd_translation.filtered_translation_element_indices_active_index]
+        mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements[mmd_translation_element_index.value]
 
         MMD_DATA_TYPE_TO_HANDLERS[mmd_translation_element.type].update_index(mmd_translation_element)
 

--- a/mmd_tools/core/translations.py
+++ b/mmd_tools/core/translations.py
@@ -659,7 +659,7 @@ class FnTranslations:
                         "org_name_j": org_name_j,
                         "org_name_e": org_name_e,
                     },
-                )
+                ),
             )
 
             if batch_operation_target == "BLENDER":

--- a/mmd_tools/core/vmd/__init__.py
+++ b/mmd_tools/core/vmd/__init__.py
@@ -11,11 +11,16 @@ class InvalidFileError(Exception):
 
 
 def _decodeCp932String(byteString):
-    """Convert a VMD format byte string to a regular string."""
-    # If the first byte is replaced with b"\x00" during encoding, add � at the beginning during decoding
-    # and replace ? with � to ensure replacement character consistency between UnicodeEncodeError and UnicodeDecodeError.
-    # UnicodeEncodeError: Bone/Morph name has characters not supported by cp932 encoding. Default replacement character: ?
-    # UnicodeDecodeError: Bone/Morph name was truncated at 15 bytes, breaking character boundaries. Default replacement character: �(U+FFFD)
+    r"""Convert a VMD format byte string to a regular string.
+    If the first byte is replaced with b"\x00" during encoding, add � at the beginning during decoding
+    and replace ? with � to ensure replacement character consistency between UnicodeEncodeError and UnicodeDecodeError.
+    - UnicodeEncodeError: Bone/Morph name has characters not supported by cp932 encoding. Default replacement character: ?
+    - UnicodeDecodeError: Bone/Morph name was truncated at 15 bytes, breaking character boundaries. Default replacement character: �(U+FFFD)
+    Example:
+        original = "左带_0_1調整"
+        byteString = b"\x00\xb6\x3f\x5f\x30\x5f\x31\x92\xb2\x90\xae\x00\x00\x00\x00"
+        decoded = "�ｶ�_0_1調整"
+    """
     decoded = byteString.replace(b"\x00", b"").decode("cp932", errors="replace")
     if byteString[:1] == b"\x00":
         decoded = "\ufffd" + decoded.replace("?", "\ufffd")

--- a/mmd_tools/core/vmd/__init__.py
+++ b/mmd_tools/core/vmd/__init__.py
@@ -53,6 +53,9 @@ class Header:
 
 
 class BoneFrameKey:
+    # Use __slots__ for better performance
+    __slots__ = ("frame_number", "location", "rotation", "interp")
+
     def __init__(self):
         self.frame_number = 0
         self.location = []
@@ -82,6 +85,9 @@ class BoneFrameKey:
 
 
 class ShapeKeyFrameKey:
+    # Use __slots__ for better performance
+    __slots__ = ("frame_number", "weight")
+
     def __init__(self):
         self.frame_number = 0
         self.weight = 0.0
@@ -102,6 +108,9 @@ class ShapeKeyFrameKey:
 
 
 class CameraKeyFrameKey:
+    # Use __slots__ for better performance
+    __slots__ = ("frame_number", "distance", "location", "rotation", "interp", "angle", "persp")
+
     def __init__(self):
         self.frame_number = 0
         self.distance = 0.0
@@ -142,6 +151,9 @@ class CameraKeyFrameKey:
 
 
 class LampKeyFrameKey:
+    # Use __slots__ for better performance
+    __slots__ = ("frame_number", "color", "direction")
+
     def __init__(self):
         self.frame_number = 0
         self.color = []
@@ -166,6 +178,9 @@ class LampKeyFrameKey:
 
 
 class SelfShadowFrameKey:
+    # Use __slots__ for better performance
+    __slots__ = ("frame_number", "mode", "distance")
+
     def __init__(self):
         self.frame_number = 0
         self.mode = 0  # 0: none, 1: mode1, 2: mode2
@@ -196,6 +211,9 @@ class SelfShadowFrameKey:
 
 
 class PropertyFrameKey:
+    # Use __slots__ for better performance
+    __slots__ = ("frame_number", "visible", "ik_states")
+
     def __init__(self):
         self.frame_number = 0
         self.visible = True

--- a/mmd_tools/core/vmd/__init__.py
+++ b/mmd_tools/core/vmd/__init__.py
@@ -61,11 +61,11 @@ class BoneFrameKey:
 
     def load(self, fin):
         (self.frame_number,) = struct.unpack("<L", fin.read(4))
-        self.location = list(struct.unpack("<fff", fin.read(4 * 3)))
-        self.rotation = list(struct.unpack("<ffff", fin.read(4 * 4)))
+        self.location = tuple(struct.unpack("<fff", fin.read(4 * 3)))
+        self.rotation = tuple(struct.unpack("<ffff", fin.read(4 * 4)))
         if not any(self.rotation):
             self.rotation = (0, 0, 0, 1)
-        self.interp = list(struct.unpack("<64b", fin.read(64)))
+        self.interp = tuple(struct.unpack("<64b", fin.read(64)))
 
     def save(self, fin):
         fin.write(struct.pack("<L", self.frame_number))
@@ -114,9 +114,9 @@ class CameraKeyFrameKey:
     def load(self, fin):
         (self.frame_number,) = struct.unpack("<L", fin.read(4))
         (self.distance,) = struct.unpack("<f", fin.read(4))
-        self.location = list(struct.unpack("<fff", fin.read(4 * 3)))
-        self.rotation = list(struct.unpack("<fff", fin.read(4 * 3)))
-        self.interp = list(struct.unpack("<24b", fin.read(24)))
+        self.location = tuple(struct.unpack("<fff", fin.read(4 * 3)))
+        self.rotation = tuple(struct.unpack("<fff", fin.read(4 * 3)))
+        self.interp = tuple(struct.unpack("<24b", fin.read(24)))
         (self.angle,) = struct.unpack("<L", fin.read(4))
         (self.persp,) = struct.unpack("<b", fin.read(1))
         self.persp = self.persp == 0
@@ -149,8 +149,8 @@ class LampKeyFrameKey:
 
     def load(self, fin):
         (self.frame_number,) = struct.unpack("<L", fin.read(4))
-        self.color = list(struct.unpack("<fff", fin.read(4 * 3)))
-        self.direction = list(struct.unpack("<fff", fin.read(4 * 3)))
+        self.color = tuple(struct.unpack("<fff", fin.read(4 * 3)))
+        self.direction = tuple(struct.unpack("<fff", fin.read(4 * 3)))
 
     def save(self, fin):
         fin.write(struct.pack("<L", self.frame_number))

--- a/mmd_tools/core/vmd/__init__.py
+++ b/mmd_tools/core/vmd/__init__.py
@@ -53,6 +53,12 @@ class Header:
 
 
 class BoneFrameKey:
+    """
+    VMD bone keyframe data structure.
+
+    TODO: Optimize this bottleneck. Large VMD files may instantiate millions of BoneFrameKey objects, significantly impacting performance.
+    """
+
     # Use __slots__ for better performance
     __slots__ = ("frame_number", "location", "rotation", "interp")
 

--- a/mmd_tools/core/vmd/__init__.py
+++ b/mmd_tools/core/vmd/__init__.py
@@ -46,7 +46,7 @@ class Header:
     def load(self, fin):
         (self.signature,) = struct.unpack("<30s", fin.read(30))
         if self.signature[: len(self.VMD_SIGN)] != self.VMD_SIGN:
-            raise InvalidFileError('File signature "%s" is invalid.' % self.signature)
+            raise InvalidFileError(f'File signature "{self.signature}" is invalid.')
         self.model_name = _decodeCp932String(struct.unpack("<20s", fin.read(20))[0])
 
     def save(self, fin):
@@ -54,7 +54,7 @@ class Header:
         fin.write(struct.pack("<20s", _encodeCp932String(self.model_name)))
 
     def __repr__(self):
-        return "<Header model_name %s>" % (self.model_name)
+        return f"<Header model_name {self.model_name}>"
 
 
 class BoneFrameKey:
@@ -88,11 +88,7 @@ class BoneFrameKey:
         fin.write(struct.pack("<64b", *self.interp))
 
     def __repr__(self):
-        return "<BoneFrameKey frame %s, loa %s, rot %s>" % (
-            str(self.frame_number),
-            str(self.location),
-            str(self.rotation),
-        )
+        return f"<BoneFrameKey frame {str(self.frame_number)}, loa {str(self.location)}, rot {str(self.rotation)}>"
 
 
 class ShapeKeyFrameKey:
@@ -112,10 +108,7 @@ class ShapeKeyFrameKey:
         fin.write(struct.pack("<f", self.weight))
 
     def __repr__(self):
-        return "<ShapeKeyFrameKey frame %s, weight %s>" % (
-            str(self.frame_number),
-            str(self.weight),
-        )
+        return f"<ShapeKeyFrameKey frame {str(self.frame_number)}, weight {str(self.weight)}>"
 
 
 class CameraKeyFrameKey:
@@ -151,14 +144,7 @@ class CameraKeyFrameKey:
         fin.write(struct.pack("<b", 0 if self.persp else 1))
 
     def __repr__(self):
-        return "<CameraKeyFrameKey frame %s, distance %s, loc %s, rot %s, angle %s, persp %s>" % (
-            str(self.frame_number),
-            str(self.distance),
-            str(self.location),
-            str(self.rotation),
-            str(self.angle),
-            str(self.persp),
-        )
+        return f"<CameraKeyFrameKey frame {str(self.frame_number)}, distance {str(self.distance)}, loc {str(self.location)}, rot {str(self.rotation)}, angle {str(self.angle)}, persp {str(self.persp)}>"
 
 
 class LampKeyFrameKey:
@@ -181,11 +167,7 @@ class LampKeyFrameKey:
         fin.write(struct.pack("<fff", *self.direction))
 
     def __repr__(self):
-        return "<LampKeyFrameKey frame %s, color %s, direction %s>" % (
-            str(self.frame_number),
-            str(self.color),
-            str(self.direction),
-        )
+        return f"<LampKeyFrameKey frame {str(self.frame_number)}, color {str(self.color)}, direction {str(self.direction)}>"
 
 
 class SelfShadowFrameKey:
@@ -214,11 +196,7 @@ class SelfShadowFrameKey:
         fin.write(struct.pack("<f", distance))
 
     def __repr__(self):
-        return "<SelfShadowFrameKey frame %s, mode %s, distance %s>" % (
-            str(self.frame_number),
-            str(self.mode),
-            str(self.distance),
-        )
+        return f"<SelfShadowFrameKey frame {str(self.frame_number)}, mode {str(self.mode)}, distance {str(self.distance)}>"
 
 
 class PropertyFrameKey:
@@ -248,11 +226,7 @@ class PropertyFrameKey:
             fin.write(struct.pack("<b", 1 if state else 0))
 
     def __repr__(self):
-        return "<PropertyFrameKey frame %s, visible %s, ik_states %s>" % (
-            str(self.frame_number),
-            str(self.visible),
-            str(self.ik_states),
-        )
+        return f"<PropertyFrameKey frame {str(self.frame_number)}, visible {str(self.visible)}, ik_states {str(self.ik_states)}>"
 
 
 class _AnimationBase(collections.defaultdict):

--- a/mmd_tools/core/vmd/exporter.py
+++ b/mmd_tools/core/vmd/exporter.py
@@ -111,8 +111,8 @@ class _FCurve:
                     break
             assert len(frames) >= 1 and frames[-1] == i
             if prev_kp is None:
-                for f in frames:  # starting key frames
-                    result.append([kp.co[1], ((20, 20), (107, 107))])
+                # starting key frames
+                result.extend([kp.co[1], ((20, 20), (107, 107))] for f in frames)
             elif len(frames) == 1:
                 result.append([kp.co[1], self.getVMDControlPoints(prev_kp, kp)])
             elif prev_kp.interpolation == "BEZIER":
@@ -122,8 +122,7 @@ class _FCurve:
                     result.append([pt.y, self.__toVMDControlPoints(b1)])
                 result.append([bz.points[-1].y, self.__toVMDControlPoints(bz)])
             else:
-                for f in frames:
-                    result.append([evaluate(f), ((20, 20), (107, 107))])
+                result.extend([evaluate(f), ((20, 20), (107, 107))] for f in frames)
             prev_kp = kp
 
         prev_kp_co_1 = prev_kp.co[1]

--- a/mmd_tools/core/vmd/exporter.py
+++ b/mmd_tools/core/vmd/exporter.py
@@ -54,8 +54,7 @@ class _FCurve:
                     result.add(max(0, round(kp1.co[0]) - 1))
                 elif kp0.interpolation == "BEZIER":
                     bz = _FnBezier.from_fcurve(kp0, kp1)
-                    for t in bz.find_critical():
-                        result.add(round(bz.evaluate(t).x))
+                    result.update(round(bz.evaluate(t).x) for t in bz.find_critical())
             kp0 = kp1
 
         return result

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -591,8 +591,7 @@ class VMDImporter:
                 frame_num = keyFrame.frame_number
                 if frame_num <= first_frame:
                     first_frame = frame_num
-                    for ikName, enable in keyFrame.ik_states:
-                        first_frame_ik_states[ikName] = enable
+                    first_frame_ik_states.update(keyFrame.ik_states)
             # Set the mmd_ik_toggle property for each bone based on the collected first frame IK states
             for ikName, enable in first_frame_ik_states.items():
                 bone = pose_bones.get(ikName, None)

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -698,11 +698,8 @@ class VMDImporter:
         if self.__mirror:
             _loc, _rot = _MirrorMapper.get_location, _MirrorMapper.get_rotation3
 
-        fcurves = []
-        for i in range(3):
-            fcurves.append(self.__get_or_create_fcurve(parent_action, "location", i))  # x, y, z
-        for i in range(3):
-            fcurves.append(self.__get_or_create_fcurve(parent_action, "rotation_euler", i))  # rx, ry, rz
+        fcurves = [self.__get_or_create_fcurve(parent_action, "location", i) for i in range(3)]  # x, y, z
+        fcurves.extend(self.__get_or_create_fcurve(parent_action, "rotation_euler", i) for i in range(3))  # rx, ry, rz
         fcurves.append(self.__get_or_create_fcurve(parent_action, "mmd_camera.angle", 0))  # fov
         fcurves.append(self.__get_or_create_fcurve(parent_action, "mmd_camera.is_perspective", 0))  # persp
         fcurves.append(self.__get_or_create_fcurve(distance_action, "location", 1))  # dis

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -375,7 +375,7 @@ class VMDImporter:
             VMDImporter.__keyframe_insert_inner(fcurves, path, 2, frame, value[2])
 
         else:
-            raise TypeError("Unsupported type: {0}".format(type(value)))
+            raise TypeError(f"Unsupported type: {type(value)}")
 
     def __getBoneConverter(self, bone):
         converter = self.__bone_util_cls(bone, self.__scale)

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -546,6 +546,20 @@ class VMDImporter:
                     # FIXME the rotation interpolation has slightly different result
                     #   Blender: rot(x) = prev_rot*(1 - bezier(t)) + curr_rot*bezier(t)
                     #       MMD: rot(x) = prev_rot.slerp(curr_rot, factor=bezier(t))
+                    # To match MMD's Slerp behavior in Blender, set bone rotation mode to XYZ Euler before importing VMD motions.
+                    # Observed behavior in Blender:
+                    #     In Quaternion mode:
+                    #          0    1    2    3    4    5    6    7    8    9   10
+                    #     W  1.0  0.9  0.8  0.7  0.6  0.5  0.4  0.3  0.2  0.1  0.0
+                    #     X  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
+                    #     Y  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
+                    #     Z  0.0  0.1  0.2  0.3  0.4  0.5  0.6  0.7  0.8  0.9  1.0
+                    #     In XYZ Euler mode:
+                    #          0    1    2    3    4    5    6    7    8    9   10
+                    #     X   0d   0d   0d   0d   0d   0d   0d   0d   0d   0d   0d
+                    #     Y   0d   0d   0d   0d   0d   0d   0d   0d   0d   0d   0d
+                    #     Z   0d  18d  36d  54d  72d  90d 108d 126d 144d 162d 180d
+                    # This suggests that Euler mode in Blender approximates MMD's use of Slerp during Bezier-driven interpolation.
                 prev_rot = curr_rot
 
                 x.co = (frame, loc[0])

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -729,6 +729,7 @@ class VMDImporter:
             if prev_kps is not None:
                 interp = k.interp
                 for idx, prev_kp, kp in zip(indices, prev_kps, curr_kps, strict=False):
+                    # TODO: Optimize this bottleneck: __setInterpolation is called per keypoint; should batch set interpolation instead
                     self.__setInterpolation(interp[idx : idx + 4 : 2] + interp[idx + 1 : idx + 4 : 2], prev_kp, kp)
             prev_kps = curr_kps
 

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -255,7 +255,7 @@ class _FnBezier:
                 D = c * c - 4 * b * d
                 if D < 0:
                     return
-                D = D**0.5
+                D **= 0.5
                 b2 = 2 * b
                 t = (-c + D) / b2
                 if 0 <= t <= 1:
@@ -274,7 +274,7 @@ class _FnBezier:
         D = A * A + B * B * B
 
         if D > 0:
-            D = D**0.5
+            D **= 0.5
             t = b_3a + _sqrt3(A + D) + _sqrt3(A - D)
             if 0 <= t <= 1:
                 yield t

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -514,7 +514,7 @@ class VMDImporter:
             fcurves = [dummy_keyframe_points] * 7  # x, y, z, r0, r1, r2, (r3)
             data_path_rot = prop_rot_map.get(bone.rotation_mode, "rotation_euler")
             bone_rotation = getattr(bone, data_path_rot)
-            default_values = list(bone.location) + list(bone_rotation)
+            default_values = tuple(bone.location) + tuple(bone_rotation)
             data_path = 'pose.bones["%s"].location' % bone.name
             for axis_i in range(3):
                 fcurves[axis_i] = self.__get_or_create_fcurve(action, data_path, axis_i, bone.name)

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -345,7 +345,6 @@ class VMDImporter:
             bezier = [20, 20, 107, 107]
 
         # Always multiply before dividing to reduce precision errors
-        d = (kp1.co - kp0.co)
         kp0.handle_right = kp0.co + Vector((d.x * bezier[0] / 127.0, d.y * bezier[1] / 127.0))
         kp1.handle_left = kp0.co + Vector((d.x * bezier[2] / 127.0, d.y * bezier[3] / 127.0))
 

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -313,7 +313,7 @@ class VMDImporter:
         self.__bone_mapper = bone_mapper
         self.__bone_util_cls = BoneConverterPoseMode if use_pose_mode else BoneConverter
         self.__frame_start = bpy.context.scene.frame_current
-        self.__frame_margin = frame_margin if self.__frame_start == 1 else 0  # Ignore margin if current frame is not 1
+        self.__frame_margin = frame_margin if self.__frame_start in {0, 1} else 0  # only applies if current frame is 0 or 1
         self.__mirror = use_mirror
         self.__always_create_new_action = always_create_new_action
         self.__use_NLA = use_NLA
@@ -529,8 +529,8 @@ class VMDImporter:
                 kp_iter = iter(new_keyframes)
                 if extra_frame:
                     kp = next(kp_iter)
-                    kp.co = (1, default_values[i])
-                    kp.interpolation = "LINEAR"
+                    kp.co = (self.__frame_start, default_values[i])
+                    kp.interpolation = "BEZIER"
                 fcurves[i] = kp_iter
 
             converter = self.__getBoneConverter(bone)

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -303,7 +303,7 @@ class HasAnimationData:
 
 
 class VMDImporter:
-    def __init__(self, filepath, scale=1.0, bone_mapper=None, use_pose_mode=False, convert_mmd_camera=True, convert_mmd_lamp=True, frame_margin=5, use_mirror=False, always_create_new_action=False, use_NLA=False, detect_camera_changes=True, detect_lamp_changes=True):
+    def __init__(self, filepath, scale=1.0, bone_mapper=None, use_pose_mode=False, convert_mmd_camera=True, convert_mmd_lamp=True, frame_margin=5, use_mirror=False, always_create_new_action=False, use_nla=False, detect_camera_changes=True, detect_lamp_changes=True):
         self.__vmdFile = vmd.File()
         self.__vmdFile.load(filepath=filepath)
         logging.debug(str(self.__vmdFile.header))
@@ -316,7 +316,7 @@ class VMDImporter:
         self.__frame_margin = frame_margin if self.__frame_start in {0, 1} else 0  # only applies if current frame is 0 or 1
         self.__mirror = use_mirror
         self.__always_create_new_action = always_create_new_action
-        self.__use_NLA = use_NLA
+        self.__use_nla = use_nla
         self.__detect_camera_changes = detect_camera_changes
         self.__detect_lamp_changes = detect_lamp_changes
 
@@ -422,7 +422,7 @@ class VMDImporter:
         if target.animation_data is None:
             target.animation_data_create()
 
-        if not self.__use_NLA:
+        if not self.__use_nla:
             if not self.__always_create_new_action and target.animation_data.action:
                 return target.animation_data.action
             target.animation_data.action = action

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -621,8 +621,7 @@ class VMDImporter:
             mmd_root = root_object.mmd_root
             # Check all types of morphs in the model
             for morph_type in ["vertex_morphs", "uv_morphs", "bone_morphs", "material_morphs", "group_morphs"]:
-                for morph in getattr(mmd_root, morph_type, []):
-                    model_morph_names.add(morph.name)
+                model_morph_names.update(morph.name for morph in getattr(mmd_root, morph_type, []))
 
         for name, keyFrames in shapeKeyAnim.items():
             if name not in shapeKeyDict:

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -514,10 +514,10 @@ class VMDImporter:
             data_path_rot = prop_rot_map.get(bone.rotation_mode, "rotation_euler")
             bone_rotation = getattr(bone, data_path_rot)
             default_values = tuple(bone.location) + tuple(bone_rotation)
-            data_path = 'pose.bones["%s"].location' % bone.name
+            data_path = f'pose.bones["{bone.name}"].location'
             for axis_i in range(3):
                 fcurves[axis_i] = self.__get_or_create_fcurve(action, data_path, axis_i, bone.name)
-            data_path = 'pose.bones["%s"].%s' % (bone.name, data_path_rot)
+            data_path = f'pose.bones["{bone.name}"].{data_path_rot}'
             for axis_i in range(len(bone_rotation)):
                 fcurves[3 + axis_i] = self.__get_or_create_fcurve(action, data_path, axis_i, bone.name)
 
@@ -634,7 +634,7 @@ class VMDImporter:
                 continue
             logging.info("(mesh) frames:%5d  name: %s", len(keyFrames), name)
             shapeKey = shapeKeyDict[name]
-            data_path = 'key_blocks["%s"].value' % shapeKey.name
+            data_path = f'key_blocks["{shapeKey.name}"].value'
             fcurve = self.__get_or_create_fcurve(action, data_path, 0)
 
             original_count = len(fcurve.keyframe_points)

--- a/mmd_tools/core/vpd/__init__.py
+++ b/mmd_tools/core/vpd/__init__.py
@@ -13,11 +13,7 @@ class VpdBone:
         self.rotation = rotation if any(rotation) else [0, 0, 0, 1]
 
     def __repr__(self):
-        return "<VpdBone %s, loc %s, rot %s>" % (
-            self.bone_name,
-            str(self.location),
-            str(self.rotation),
-        )
+        return f"<VpdBone {self.bone_name}, loc {str(self.location)}, rot {str(self.rotation)}>"
 
 
 class VpdMorph:
@@ -26,10 +22,7 @@ class VpdMorph:
         self.weight = weight
 
     def __repr__(self):
-        return "<VpdMorph %s, weight %f>" % (
-            self.morph_name,
-            self.weight,
-        )
+        return f"<VpdMorph {self.morph_name}, weight {self.weight:f}>"
 
 
 class File:

--- a/mmd_tools/core/vpd/__init__.py
+++ b/mmd_tools/core/vpd/__init__.py
@@ -44,7 +44,7 @@ class File:
         path = args["filepath"]
 
         encoding = "cp932"
-        with open(path, "rt", encoding=encoding, errors="replace") as fin:
+        with open(path, encoding=encoding, errors="replace") as fin:
             self.filepath = path
             if not fin.readline().startswith("Vocaloid Pose Data file"):
                 raise InvalidFileError
@@ -87,7 +87,7 @@ class File:
         path = args.get("filepath", self.filepath)
 
         encoding = "cp932"
-        with open(path, "wt", encoding=encoding, errors="replace", newline="") as fout:
+        with open(path, "w", encoding=encoding, errors="replace", newline="") as fout:
             self.filepath = path
             fout.write("Vocaloid Pose Data file\r\n")
 

--- a/mmd_tools/core/vpd/exporter.py
+++ b/mmd_tools/core/vpd/exporter.py
@@ -133,4 +133,4 @@ class VPDExporter:
                 self.__bone_util_cls = importer.BoneConverterPoseMode
             self.__exportPoseLib(armature, pose_type, filepath, use_pose_mode)
         else:
-            raise ValueError('Unknown pose type "{pose_type}"')
+            raise ValueError(f'Unknown pose type "{pose_type}"')

--- a/mmd_tools/core/vpd/importer.py
+++ b/mmd_tools/core/vpd/importer.py
@@ -65,13 +65,13 @@ class VPDImporter:
                 bone_rotation = getattr(bone, data_path_rot)
                 fcurves = [None] * (3 + len(bone_rotation))  # x, y, z, r0, r1, r2, (r3)
 
-                data_path = 'pose.bones["%s"].location' % bone.name
+                data_path = f'pose.bones["{bone.name}"].location'
                 for axis_i in range(3):
                     fcurves[axis_i] = action.fcurves.find(data_path, index=axis_i)
                     if fcurves[axis_i] is None:
                         fcurves[axis_i] = action.fcurves.new(data_path=data_path, index=axis_i, action_group=bone.name)
 
-                data_path = 'pose.bones["%s"].%s' % (bone.name, data_path_rot)
+                data_path = f'pose.bones["{bone.name}"].{data_path_rot}'
                 for axis_i in range(len(bone_rotation)):
                     fcurves[3 + axis_i] = action.fcurves.find(data_path, index=axis_i)
                     if fcurves[3 + axis_i] is None:
@@ -125,7 +125,7 @@ class VPDImporter:
             shape_key.value = m.weight
 
             # Create or get FCurve
-            data_path = 'key_blocks["%s"].value' % shape_key.name
+            data_path = f'key_blocks["{shape_key.name}"].value'
             fcurve = action.fcurves.find(data_path)
             if fcurve is None:
                 fcurve = action.fcurves.new(data_path=data_path)

--- a/mmd_tools/cycles_converter.py
+++ b/mmd_tools/cycles_converter.py
@@ -91,16 +91,16 @@ def __enum_linked_nodes(node: bpy.types.Node) -> Iterable[bpy.types.Node]:
     yield node
     if node.parent:
         yield node.parent
-    for n in set(link.from_node for i in node.inputs for link in i.links):
+    for n in {link.from_node for i in node.inputs for link in i.links}:
         yield from __enum_linked_nodes(n)
 
 
 def __cleanNodeTree(material: bpy.types.Material):
     nodes = material.node_tree.nodes
-    node_names = set(n.name for n in nodes)
+    node_names = {n.name for n in nodes}
     for o in (n for n in nodes if n.bl_idname in {"ShaderNodeOutput", "ShaderNodeOutputMaterial"}):
         if any(i.is_linked for i in o.inputs):
-            node_names -= set(linked.name for linked in __enum_linked_nodes(o))
+            node_names -= {linked.name for linked in __enum_linked_nodes(o)}
     for name in node_names:
         nodes.remove(nodes[name])
 

--- a/mmd_tools/externals/opencc/__init__.py
+++ b/mmd_tools/externals/opencc/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (C) 2016 Yichen Huang (Eugene)
+# Licensed under the Apache License, Version 2.0
 ##########################################################
 # Author: Yichen Huang (Eugene)
 # GitHub: https://github.com/yichen0831/opencc-python

--- a/mmd_tools/externals/opencc/__main__.py
+++ b/mmd_tools/externals/opencc/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import argparse
 import sys
 

--- a/mmd_tools/externals/opencc/__main__.py
+++ b/mmd_tools/externals/opencc/__main__.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import argparse
-import io
 import sys
 
 from opencc import OpenCC
@@ -29,7 +28,7 @@ def main():
     cc = OpenCC(args.config)
 
     if args.input:
-        with io.open(args.input, encoding=args.in_enc) as f:
+        with open(args.input, encoding=args.in_enc) as f:
             input_str = f.read()
     else:
         input_str = sys.stdin.read()
@@ -37,7 +36,7 @@ def main():
     output_str = cc.convert(input_str)
 
     if args.output:
-        with io.open(args.output, "w", encoding=args.out_enc) as f:
+        with open(args.output, "w", encoding=args.out_enc) as f:
             f.write(output_str)
     else:
         sys.stdout.write(output_str)

--- a/mmd_tools/externals/opencc/__main__.py
+++ b/mmd_tools/externals/opencc/__main__.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2016 Yichen Huang (Eugene)
+# Licensed under the Apache License, Version 2.0
+
 import argparse
 import sys
 

--- a/mmd_tools/externals/opencc/opencc.py
+++ b/mmd_tools/externals/opencc/opencc.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # - Use "from __future__ import" to allow support for both Python 2.7
 #   and Python >3.2
 ##########################################################
-import io
 import json
 import os
 import re
@@ -128,7 +127,7 @@ class OpenCC:
                 max_len = 1
                 # Default min key length to very large value
                 min_len = 1000
-                with io.open(item, "r", encoding="utf-8") as f:
+                with open(item, "r", encoding="utf-8") as f:
                     for line in f:
                         key, value = line.strip().split("\t")
                         map_dict[key] = value

--- a/mmd_tools/externals/opencc/opencc.py
+++ b/mmd_tools/externals/opencc/opencc.py
@@ -99,7 +99,7 @@ class OpenCC:
         self._dict_chain = []
         config = self.conversion + ".json"
         config_file = os.path.join(os.path.dirname(__file__), CONFIG_DIR, config)
-        with open(config_file) as f:
+        with open(config_file, encoding="utf-8") as f:
             setting_json = json.load(f)
 
         self.conversion_name = setting_json.get("name")

--- a/mmd_tools/externals/opencc/opencc.py
+++ b/mmd_tools/externals/opencc/opencc.py
@@ -170,7 +170,7 @@ class OpenCC:
 #############################################
 
 
-class TreeNode(object):
+class TreeNode:
     LEFT = 0
     RIGHT = 1
 
@@ -193,7 +193,7 @@ class TreeNode(object):
         self.length_hint = hint
 
 
-class StringTree(object):
+class StringTree:
     def __init__(self, string):
         self.root = TreeNode(string)
 

--- a/mmd_tools/externals/opencc/opencc.py
+++ b/mmd_tools/externals/opencc/opencc.py
@@ -127,7 +127,7 @@ class OpenCC:
                 max_len = 1
                 # Default min key length to very large value
                 min_len = 1000
-                with open(item, "r", encoding="utf-8") as f:
+                with open(item, encoding="utf-8") as f:
                     for line in f:
                         key, value = line.strip().split("\t")
                         map_dict[key] = value

--- a/mmd_tools/externals/opencc/opencc.py
+++ b/mmd_tools/externals/opencc/opencc.py
@@ -132,10 +132,8 @@ class OpenCC:
                     for line in f:
                         key, value = line.strip().split("\t")
                         map_dict[key] = value
-                        if len(key) > max_len:
-                            max_len = len(key)
-                        if len(key) < min_len:
-                            min_len = len(key)
+                        max_len = max(max_len, len(key))
+                        min_len = min(min_len, len(key))
                 chain_data.append((max_len, min_len, map_dict))
                 self.dict_cache[item] = (max_len, min_len, map_dict)
             else:

--- a/mmd_tools/externals/opencc/opencc.py
+++ b/mmd_tools/externals/opencc/opencc.py
@@ -1,3 +1,5 @@
+# Copyright (C) 2016 Yichen Huang (Eugene)
+# Licensed under the Apache License, Version 2.0
 ##########################################################
 # Author: Yichen Huang (Eugene)
 # GitHub: https://github.com/yichen0831/opencc-python

--- a/mmd_tools/externals/opencc/opencc.py
+++ b/mmd_tools/externals/opencc/opencc.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 ##########################################################
 # Author: Yichen Huang (Eugene)
 # GitHub: https://github.com/yichen0831/opencc-python

--- a/mmd_tools/m17n.py
+++ b/mmd_tools/m17n.py
@@ -6133,5 +6133,5 @@ if __name__ == "__main__":
 
     for lang, cnt in untranslated_count.items():
         print(
-            f"Of {total_count} entries, {cnt} have not been translated for language {lang}"
+            f"Of {total_count} entries, {cnt} have not been translated for language {lang}",
         )

--- a/mmd_tools/m17n.py
+++ b/mmd_tools/m17n.py
@@ -1778,13 +1778,13 @@ translations_tuple = (
     ),
     (
         ("*", "Fix IK Links"),
-        (("bpy.types.MMD_TOOLS_OT_import_model.fix_IK_links",), ()),
+        (("bpy.types.MMD_TOOLS_OT_import_model.fix_ik_links",), ()),
         ("ja_JP", "IKリンクを修正", (False, ())),
         ("zh_HANS", "修复IK关联", (False, ())),
     ),
     (
         ("*", "Fix IK links to be blender suitable"),
-        (("bpy.types.MMD_TOOLS_OT_import_model.fix_IK_links",), ()),
+        (("bpy.types.MMD_TOOLS_OT_import_model.fix_ik_links",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "修复逆向运动学关联，使其适合被 Blender 处理", (False, ())),
     ),
@@ -2057,13 +2057,13 @@ translations_tuple = (
     ),
     (
         ("*", "Use NLA"),
-        (("bpy.types.MMD_TOOLS_OT_import_vmd.use_NLA",), ()),
+        (("bpy.types.MMD_TOOLS_OT_import_vmd.use_nla",), ()),
         ("ja_JP", "NLAを使用", (False, ())),
         ("zh_HANS", "使用NLA", (False, ())),
     ),
     (
         ("*", "Import the motion as NLA strips"),
-        (("bpy.types.MMD_TOOLS_OT_import_vmd.use_NLA",), ()),
+        (("bpy.types.MMD_TOOLS_OT_import_vmd.use_nla",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "将动作导入为非线性动作片段", (False, ())),
     ),

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -266,6 +266,11 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
         subtype="ANGLE",
         unit="ROTATION",
     )
+    import_adduv2_as_vertex_colors: bpy.props.BoolProperty(
+        name="Import ADD UV2 as Vertex Colors",
+        description="Import ADD UV2 data as vertex colors in addition to additional UV layers",
+        default=False,
+    )
     fix_IK_links: bpy.props.BoolProperty(
         name="Fix IK Links",
         description="Fix IK links to be blender suitable",
@@ -368,6 +373,7 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
                 remove_doubles=self.remove_doubles,
                 mark_sharp_edges=self.mark_sharp_edges,
                 sharp_edge_angle=self.sharp_edge_angle,
+                import_adduv2_as_vertex_colors=self.import_adduv2_as_vertex_colors,
                 fix_IK_links=self.fix_IK_links,
                 ik_loop_factor=self.ik_loop_factor,
                 apply_bone_fixed_axis=self.apply_bone_fixed_axis,

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -384,7 +384,7 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
                 sph_blend_factor=self.sph_blend_factor,
                 spa_blend_factor=self.spa_blend_factor,
             )
-            self.report({"INFO"}, 'Imported MMD model from "%s"' % self.filepath)
+            self.report({"INFO"}, f'Imported MMD model from "{self.filepath}"')
         except Exception:
             logging.exception("Error occurred")
             raise
@@ -844,7 +844,7 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
 
         arm = FnModel.find_armature_object(root)
         if arm is None:
-            self.report({"ERROR"}, '[Skipped] The armature object of MMD model "%s" can\'t be found' % root.name)
+            self.report({"ERROR"}, f'[Skipped] The armature object of MMD model "{root.name}" can\'t be found')
             return {"CANCELLED"}
         orig_pose_position = None
         if not root.mmd_root.is_built:  # use 'REST' pose when the model is not built
@@ -875,7 +875,7 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
                 export_vertex_colors_as_adduv2=self.export_vertex_colors_as_adduv2,
                 ik_angle_limits=self.ik_angle_limits,
             )
-            self.report({"INFO"}, 'Exported MMD model "%s" to "%s"' % (root.name, self.filepath))
+            self.report({"INFO"}, f'Exported MMD model "{root.name}" to "{self.filepath}"')
         except Exception:
             logging.exception("Error occurred")
             raise

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -344,6 +344,7 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
             elif self.filepath:
                 self._do_execute(context)
         except Exception:
+            logging.exception("Error occurred")
             err_msg = traceback.format_exc()
             self.report({"ERROR"}, err_msg)
         return {"FINISHED"}
@@ -379,8 +380,7 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
             )
             self.report({"INFO"}, 'Imported MMD model from "%s"' % self.filepath)
         except Exception:
-            err_msg = traceback.format_exc()
-            logging.error(err_msg)
+            logging.exception("Error occurred")
             raise
         finally:
             if self.save_log:
@@ -819,6 +819,7 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
                     self.filepath = os.path.join(model_folder, model_name + ".pmx")
                 self._do_execute(context, root)
         except Exception:
+            logging.exception("Error occurred")
             err_msg = traceback.format_exc()
             self.report({"ERROR"}, err_msg)
         return {"FINISHED"}
@@ -864,8 +865,7 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
             )
             self.report({"INFO"}, 'Exported MMD model "%s" to "%s"' % (root.name, self.filepath))
         except Exception:
-            err_msg = traceback.format_exc()
-            logging.error(err_msg)
+            logging.exception("Error occurred")
             raise
         finally:
             if orig_pose_position:
@@ -963,10 +963,9 @@ class ExportVmd(Operator, ExportHelper, PreferencesMixin):
             vmd_exporter.VMDExporter().export(**params)
             logging.info(" Finished exporting motion in %f seconds.", time.time() - start_time)
         except Exception:
+            logging.exception("Error occurred")
             err_msg = traceback.format_exc()
-            logging.error(err_msg)
             self.report({"ERROR"}, err_msg)
-
         return {"FINISHED"}
 
 
@@ -1053,7 +1052,7 @@ class ExportVpd(Operator, ExportHelper, PreferencesMixin):
         try:
             vpd_exporter.VPDExporter().export(**params)
         except Exception:
+            logging.exception("Error occurred")
             err_msg = traceback.format_exc()
-            logging.error(err_msg)
             self.report({"ERROR"}, err_msg)
         return {"FINISHED"}

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -124,7 +124,7 @@ def apply_operator_preset(operator, preset_name):
         # Execute preset with proper context
         with bpy.context.temp_override(active_operator=operator):
             try:
-                with open(preset_file, "r", encoding="utf-8") as f:
+                with open(preset_file, encoding="utf-8") as f:
                     preset_code = f.read()
 
                 namespace = {"bpy": bpy}

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -697,7 +697,7 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
     )
     sort_materials: bpy.props.BoolProperty(
         name="Sort Materials",
-        description=("Sort materials for alpha blending. " "WARNING: Will not work if you have " + "transparent meshes inside the model. " + "E.g. blush meshes"),
+        description="Sort materials for alpha blending. WARNING: Will not work if you have transparent meshes inside the model. E.g. blush meshes",
         default=False,
     )
     disable_specular: bpy.props.BoolProperty(

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -414,7 +414,7 @@ class ImportVmd(Operator, ImportHelper, PreferencesMixin):
     )
     margin: bpy.props.IntProperty(
         name="Margin",
-        description="Number of frames to add before the motion starts (only applies if current frame is 1)",
+        description="Number of frames to add before the motion starts (only applies if current frame is 0 or 1)",
         min=0,
         default=0,
     )

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -460,8 +460,8 @@ class ImportVmd(Operator, ImportHelper, PreferencesMixin):
         default=True,
     )
     always_create_new_action: bpy.props.BoolProperty(
-        name="Always Create New Action",
-        description="Always create a new action when importing VMD, otherwise add keyframes to existing actions if available. Note: This option is ignored when 'Use NLA' is enabled.",
+        name="Create New Action",
+        description="Create a new action when importing VMD, otherwise add keyframes to existing actions if available. Note: This option is ignored when 'Use NLA' is enabled.",
         default=False,
     )
     use_NLA: bpy.props.BoolProperty(

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -267,8 +267,8 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
         unit="ROTATION",
     )
     import_adduv2_as_vertex_colors: bpy.props.BoolProperty(
-        name="Import ADD UV2 as Vertex Colors",
-        description="Import ADD UV2 data as vertex colors in addition to additional UV layers",
+        name="Import Vertex Colors",
+        description="Import ADD UV2 data as vertex colors. When enabled, the UV2 layer will still be created.",
         default=False,
     )
     fix_IK_links: bpy.props.BoolProperty(
@@ -748,7 +748,7 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
         default="NONE",
     )
     export_vertex_colors_as_adduv2: bpy.props.BoolProperty(
-        name="Export Vertex Colors as ADD UV2",
+        name="Export Vertex Colors",
         description="Export vertex colors as ADD UV2 data. This allows vertex color data to be preserved in the PMX file format. When enabled, existing ADD UV2 data on the model will be skipped during export.",
         default=False,
     )

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -725,11 +725,11 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
         description=(
             "Vertex Splitting for Custom Split Normals\n"
             "ENABLE:\n"
-            "    Split vertices when the same vertex has different normals or vertex colors.\n"
+            "    Split vertices when the same vertex has different normals.\n"
             "DISABLE:\n"
-            "    Use angle * area weighted averaging for normals and vertex colors.\n"
+            "    Use angle * area weighted averaging for normals.\n"
             "WARNING:\n"
-            "    Enabling vertex splitting will break model geometry by severing connections between faces to preserve multiple custom split normals or vertex colors per vertex, and can significantly increase the vertex count. Use with caution.\n"
+            "    Enabling vertex splitting will break model geometry by severing connections between faces to preserve multiple custom split normals per vertex, and can significantly increase the vertex count. Use with caution.\n"
             "\n"
             "NOTE:\n"
             "    UV coordinates will always use vertex splitting, as they cannot be averaged. Therefore, the vertex count may still increase after export even when this option is disabled. Please try to maintain UV continuity when possible.\n"
@@ -746,6 +746,11 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
             ("CUSTOM", "Custom", 'Use custom vertex weight of vertex group "mmd_vertex_order"', 2),
         ],
         default="NONE",
+    )
+    export_vertex_colors_as_adduv2: bpy.props.BoolProperty(
+        name="Export Vertex Colors as ADD UV2",
+        description="Export vertex colors as ADD UV2 data. This allows vertex color data to be preserved in the PMX file format. When enabled, existing ADD UV2 data on the model will be skipped during export.",
+        default=False,
     )
     ik_angle_limits: bpy.props.EnumProperty(
         name="IK Angle Limits",
@@ -867,6 +872,7 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
                 sort_vertices=self.sort_vertices,
                 disable_specular=self.disable_specular,
                 vertex_splitting=self.vertex_splitting,
+                export_vertex_colors_as_adduv2=self.export_vertex_colors_as_adduv2,
                 ik_angle_limits=self.ik_angle_limits,
             )
             self.report({"INFO"}, 'Exported MMD model "%s" to "%s"' % (root.name, self.filepath))

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -271,7 +271,7 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
         description="Import ADD UV2 data as vertex colors. When enabled, the UV2 layer will still be created.",
         default=False,
     )
-    fix_IK_links: bpy.props.BoolProperty(
+    fix_ik_links: bpy.props.BoolProperty(
         name="Fix IK Links",
         description="Fix IK links to be blender suitable",
         default=False,
@@ -374,7 +374,7 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
                 mark_sharp_edges=self.mark_sharp_edges,
                 sharp_edge_angle=self.sharp_edge_angle,
                 import_adduv2_as_vertex_colors=self.import_adduv2_as_vertex_colors,
-                fix_IK_links=self.fix_IK_links,
+                fix_ik_links=self.fix_ik_links,
                 ik_loop_factor=self.ik_loop_factor,
                 apply_bone_fixed_axis=self.apply_bone_fixed_axis,
                 rename_LR_bones=self.rename_bones,
@@ -464,7 +464,7 @@ class ImportVmd(Operator, ImportHelper, PreferencesMixin):
         description="Create a new action when importing VMD, otherwise add keyframes to existing actions if available. Note: This option is ignored when 'Use NLA' is enabled.",
         default=False,
     )
-    use_NLA: bpy.props.BoolProperty(
+    use_nla: bpy.props.BoolProperty(
         name="Use NLA",
         description="Import the motion as NLA strips",
         default=False,
@@ -504,7 +504,7 @@ class ImportVmd(Operator, ImportHelper, PreferencesMixin):
         layout.prop(self, "scale")
         layout.prop(self, "margin")
         layout.prop(self, "always_create_new_action")
-        layout.prop(self, "use_NLA")
+        layout.prop(self, "use_nla")
 
         layout.prop(self, "bone_mapper")
         if self.bone_mapper == "RENAMED_BONES":
@@ -552,7 +552,7 @@ class ImportVmd(Operator, ImportHelper, PreferencesMixin):
                 frame_margin=self.margin,
                 use_mirror=self.use_mirror,
                 always_create_new_action=self.always_create_new_action,
-                use_NLA=self.use_NLA,
+                use_nla=self.use_nla,
                 detect_camera_changes=self.detect_camera_changes,
                 detect_lamp_changes=self.detect_lamp_changes,
             )

--- a/mmd_tools/operators/misc.py
+++ b/mmd_tools/operators/misc.py
@@ -42,7 +42,7 @@ class MoveObject(bpy.types.Operator, utils.ItemMoveOp):
     def set_index(cls, obj, index):
         m = cls.__PREFIX_REGEXP.match(obj.name)
         name = m.group("name") if m else obj.name
-        obj.name = "%s_%s" % (utils.int2base(index, 36, 3), name)
+        obj.name = f"{utils.int2base(index, 36, 3)}_{name}"
 
     @classmethod
     def get_name(cls, obj, prefix=None):
@@ -63,7 +63,7 @@ class MoveObject(bpy.types.Operator, utils.ItemMoveOp):
         obj = context.active_object
         objects = self.__get_objects(obj)
         if obj not in objects:
-            self.report({"ERROR"}, 'Can not move object "%s"' % obj.name)
+            self.report({"ERROR"}, f'Can not move object "{obj.name}"')
             return {"CANCELLED"}
 
         objects.sort(key=lambda x: x.name)

--- a/mmd_tools/operators/model_edit.py
+++ b/mmd_tools/operators/model_edit.py
@@ -194,7 +194,7 @@ class ModelSeparateByBonesOperator(bpy.types.Operator):
                 [
                     joint_object.rigid_body_constraint.object1 in separate_rigid_bodies,
                     joint_object.rigid_body_constraint.object2 in separate_rigid_bodies,
-                ]
+                ],
             )
         }
 
@@ -264,7 +264,7 @@ class ModelSeparateByBonesOperator(bpy.types.Operator):
             overwrite=True,
             replace_name2values={
                 # replace related_mesh property values
-                "related_mesh": {m.data.name: s.data.name for m, s in model2separate_mesh_objects.items()}
+                "related_mesh": {m.data.name: s.data.name for m, s in model2separate_mesh_objects.items()},
             },
         )
 

--- a/mmd_tools/operators/model_edit.py
+++ b/mmd_tools/operators/model_edit.py
@@ -12,8 +12,8 @@ from ..bpyutils import FnContext, select_object
 from ..core.model import FnModel, Model
 
 
-class MessageException(Exception):
-    """Class for error with message."""
+class NoModelSelectedError(Exception):
+    """Raised when no MMD model is selected."""
 
 
 class ModelJoinByBonesOperator(bpy.types.Operator):
@@ -54,7 +54,7 @@ class ModelJoinByBonesOperator(bpy.types.Operator):
     def execute(self, context: bpy.types.Context):
         try:
             self.join(context)
-        except MessageException as ex:
+        except NoModelSelectedError as ex:
             self.report(type={"ERROR"}, message=str(ex))
             return {"CANCELLED"}
 
@@ -68,7 +68,7 @@ class ModelJoinByBonesOperator(bpy.types.Operator):
         child_root_objects.remove(parent_root_object)
 
         if parent_root_object is None or len(child_root_objects) == 0:
-            raise MessageException("No MMD Models selected")
+            raise NoModelSelectedError("No MMD Models selected")
 
         # Save original active_layer_collection
         orig_active_layer_collection = context.view_layer.active_layer_collection
@@ -141,7 +141,7 @@ class ModelSeparateByBonesOperator(bpy.types.Operator):
     def execute(self, context: bpy.types.Context):
         try:
             self.separate(context)
-        except MessageException as ex:
+        except NoModelSelectedError as ex:
             self.report(type={"ERROR"}, message=str(ex))
             return {"CANCELLED"}
 

--- a/mmd_tools/operators/morph.py
+++ b/mmd_tools/operators/morph.py
@@ -588,7 +588,7 @@ class ViewUVMorph(bpy.types.Operator):
 
         selected = meshObj.select_get()
         with bpyutils.select_object(meshObj):
-            mesh = cast(bpy.types.Mesh, meshObj.data)
+            mesh = cast("bpy.types.Mesh", meshObj.data)
             morph = mmd_root.uv_morphs[mmd_root.active_morph]
             uv_textures = mesh.uv_layers
 
@@ -681,7 +681,7 @@ class EditUVMorph(bpy.types.Operator):
 
         selected = meshObj.select_get()
         with bpyutils.select_object(meshObj):
-            mesh = cast(bpy.types.Mesh, meshObj.data)
+            mesh = cast("bpy.types.Mesh", meshObj.data)
             bpy.ops.object.mode_set(mode="EDIT")
             bpy.ops.mesh.select_mode(type="VERT", action="ENABLE")
             bpy.ops.mesh.reveal()  # unhide all vertices
@@ -723,7 +723,7 @@ class ApplyUVMorph(bpy.types.Operator):
 
         selected = meshObj.select_get()
         with bpyutils.select_object(meshObj):
-            mesh = cast(bpy.types.Mesh, meshObj.data)
+            mesh = cast("bpy.types.Mesh", meshObj.data)
             morph = mmd_root.uv_morphs[mmd_root.active_morph]
 
             base_uv_name = mesh.uv_layers.active.name[5:]

--- a/mmd_tools/operators/morph.py
+++ b/mmd_tools/operators/morph.py
@@ -138,7 +138,7 @@ class CopyMorph(bpy.types.Operator):
         if morph is None:
             return {"CANCELLED"}
 
-        name_orig, name_tmp = morph.name, "_tmp%s" % str(morph.as_pointer())
+        name_orig, name_tmp = morph.name, f"_tmp{str(morph.as_pointer())}"
 
         if morph_type.startswith("vertex"):
             for obj in FnModel.iterate_mesh_objects(root):
@@ -365,12 +365,12 @@ class CreateWorkMaterial(bpy.types.Operator):
 
         base_mat = meshObj.data.materials.get(mat_data.material, None)
         if base_mat is None:
-            self.report({"ERROR"}, 'Material "%s" not found' % mat_data.material)
+            self.report({"ERROR"}, f'Material "{mat_data.material}" not found')
             return {"CANCELLED"}
 
         work_mat_name = base_mat.name + "_temp"
         if work_mat_name in bpy.data.materials:
-            self.report({"ERROR"}, 'Temporary material "%s" is in use' % work_mat_name)
+            self.report({"ERROR"}, f'Temporary material "{work_mat_name}" is in use')
             return {"CANCELLED"}
 
         work_mat = base_mat.copy()
@@ -429,7 +429,7 @@ class ClearTempMaterials(bpy.types.Operator):
                         FnMaterial.swap_materials(meshObj, m.name, base_mat_name)
                         return True
                     except MaterialNotFoundError:
-                        self.report({"WARNING"}, "Base material for %s was not found" % m.name)
+                        self.report({"WARNING"}, f"Base material for {m.name} was not found")
                 return False
 
             FnMaterial.clean_materials(meshObj, can_remove=__pre_remove)
@@ -602,7 +602,7 @@ class ViewUVMorph(bpy.types.Operator):
                 uv_textures.active = uv_textures[uv_layer_name]
 
             uv_layer_name = uv_textures.active.name
-            uv_tex = uv_textures.new(name="__uv.%s" % uv_layer_name)
+            uv_tex = uv_textures.new(name=f"__uv.{uv_layer_name}")
             if uv_tex is None:
                 self.report({"ERROR"}, "Failed to create a temporary uv layer")
                 return {"CANCELLED"}
@@ -728,7 +728,7 @@ class ApplyUVMorph(bpy.types.Operator):
 
             base_uv_name = mesh.uv_layers.active.name[5:]
             if base_uv_name not in mesh.uv_layers:
-                self.report({"ERROR"}, ' * UV map "%s" not found' % base_uv_name)
+                self.report({"ERROR"}, f' * UV map "{base_uv_name}" not found')
                 return {"CANCELLED"}
 
             base_uv_data = mesh.uv_layers[base_uv_name].data

--- a/mmd_tools/operators/rigid_body.py
+++ b/mmd_tools/operators/rigid_body.py
@@ -236,8 +236,8 @@ class AddRigidBody(bpy.types.Operator):
     def execute(self, context):
         active_object = context.active_object
 
-        root_object = cast(bpy.types.Object, FnModel.find_root_object(active_object))
-        armature_object = cast(bpy.types.Object, FnModel.find_armature_object(root_object))
+        root_object = cast("bpy.types.Object", FnModel.find_root_object(active_object))
+        armature_object = cast("bpy.types.Object", FnModel.find_armature_object(root_object))
 
         if active_object != armature_object:
             FnContext.select_single_object(context, root_object).select_set(False)
@@ -441,9 +441,9 @@ class AddJoint(bpy.types.Operator):
 
     def execute(self, context):
         active_object = context.active_object
-        root_object = cast(bpy.types.Object, FnModel.find_root_object(active_object))
-        armature_object = cast(bpy.types.Object, FnModel.find_armature_object(root_object))
-        bones = cast(bpy.types.Armature, armature_object.data).bones
+        root_object = cast("bpy.types.Object", FnModel.find_root_object(active_object))
+        armature_object = cast("bpy.types.Object", FnModel.find_armature_object(root_object))
+        bones = cast("bpy.types.Armature", armature_object.data).bones
         bone_map: Dict[bpy.types.Object, Optional[bpy.types.Bone]] = {r: bones.get(r.mmd_rigid.bone, None) for r in FnModel.iterate_rigid_body_objects(root_object) if r.select_get()}
 
         if len(bone_map) < 2:

--- a/mmd_tools/operators/translations.py
+++ b/mmd_tools/operators/translations.py
@@ -127,7 +127,7 @@ class TranslateMMDModel(bpy.types.Operator):
 
         if "DISPLAY" in self.types:
             g: bpy.types.BoneCollection
-            for g in cast(bpy.types.Armature, rig.armature().data).collections:
+            for g in cast("bpy.types.Armature", rig.armature().data).collections:
                 g.name = self.translate(g.name, g.name)
 
         if "PHYSICS" in self.types:

--- a/mmd_tools/operators/translations.py
+++ b/mmd_tools/operators/translations.py
@@ -84,7 +84,7 @@ class TranslateMMDModel(bpy.types.Operator):
         try:
             self.__translator = DictionaryEnum.get_translator(self.dictionary)
         except Exception as e:
-            self.report({"ERROR"}, "Failed to load dictionary: %s" % e)
+            self.report({"ERROR"}, f"Failed to load dictionary: {e}")
             return {"CANCELLED"}
 
         obj = context.active_object
@@ -93,7 +93,7 @@ class TranslateMMDModel(bpy.types.Operator):
 
         if "MMD" in self.modes:
             for i in self.types:
-                getattr(self, "translate_%s" % i.lower())(rig)
+                getattr(self, f"translate_{i.lower()}")(rig)
 
         if "BLENDER" in self.modes:
             self.translate_blender_names(rig)

--- a/mmd_tools/operators/translations.py
+++ b/mmd_tools/operators/translations.py
@@ -199,7 +199,7 @@ DEFAULT_SHOW_ROW_COUNT = 20
 
 class MMD_TOOLS_UL_MMDTranslationElementIndex(bpy.types.UIList):
     def draw_item(self, context, layout: bpy.types.UILayout, data, mmd_translation_element_index: "MMDTranslationElementIndex", icon, active_data, active_propname, index: int):
-        mmd_translation_element: "MMDTranslationElement" = data.translation_elements[mmd_translation_element_index.value]
+        mmd_translation_element: MMDTranslationElement = data.translation_elements[mmd_translation_element_index.value]
         MMD_DATA_TYPE_TO_HANDLERS[mmd_translation_element.type].draw_item(layout, mmd_translation_element, index)
 
 
@@ -298,7 +298,7 @@ class GlobalTranslationPopup(bpy.types.Operator):
         if root_object is None:
             return {"CANCELLED"}
 
-        mmd_translation: "MMDTranslation" = root_object.mmd_root.translation
+        mmd_translation: MMDTranslation = root_object.mmd_root.translation
         self._mmd_translation = mmd_translation
         FnTranslations.clear_data(mmd_translation)
         FnTranslations.collect_data(mmd_translation)

--- a/mmd_tools/panels/prop_bone.py
+++ b/mmd_tools/panels/prop_bone.py
@@ -23,9 +23,9 @@ class MMDBonePanel(bpy.types.Panel):
             row = self.layout.column(align=True)
             for name in ik_bone_names:
                 if name in ik_custom_map:
-                    row.prop(bones[name].mmd_bone, "ik_rotation_constraint", text="IK Angle {%s}" % name)
+                    row.prop(bones[name].mmd_bone, "ik_rotation_constraint", text=f"IK Angle {{{name}}}")
                 else:
-                    row.prop(pose_bone.mmd_bone, "ik_rotation_constraint", text="IK Angle (%s)" % name)
+                    row.prop(pose_bone.mmd_bone, "ik_rotation_constraint", text=f"IK Angle ({name})")
 
     def draw(self, context):
         pose_bone = context.active_pose_bone or context.active_object.pose.bones.get(context.active_bone.name, None)

--- a/mmd_tools/panels/sidebar/bone_order.py
+++ b/mmd_tools/panels/sidebar/bone_order.py
@@ -224,7 +224,7 @@ class MMDToolsRealignBoneIds(bpy.types.Operator):
         collection_map = {
             "Layer 1": {"new_name": "mmd_normal", "should_be_shadow": False},
             "Layer 9": {"new_name": BONE_COLLECTION_NAME_SHADOW, "should_be_shadow": True},
-            "Layer 10": {"new_name": BONE_COLLECTION_NAME_DUMMY, "should_be_shadow": True}
+            "Layer 10": {"new_name": BONE_COLLECTION_NAME_DUMMY, "should_be_shadow": True},
         }
 
         # Check if all three collections exist

--- a/mmd_tools/panels/sidebar/model_setup.py
+++ b/mmd_tools/panels/sidebar/model_setup.py
@@ -99,6 +99,8 @@ class MMDToolsModelSetupPanel(PT_PanelBase, bpy.types.Panel):
         self.__toggle_items_ttl = time.time() + 10
         self.__toggle_items_cache = []
         armature_object = FnModel.find_armature_object(mmd_root_object)
+        if armature_object is None:
+            return self.__toggle_items_cache
         pose_bones = armature_object.pose.bones
         ik_map = {pose_bones[c.subtarget]: (b.bone, c.chain_count, not c.is_valid) for b in pose_bones for c in b.constraints if c.type == "IK" and c.subtarget in pose_bones}
 

--- a/mmd_tools/panels/sidebar/morph_tools.py
+++ b/mmd_tools/panels/sidebar/morph_tools.py
@@ -182,6 +182,9 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
         row.operator(operators_morph.ApplyBoneMorph.bl_idname, text="Apply")
         row.operator(operators_morph.ClearBoneMorphView.bl_idname, text="Clear")
 
+        row = col.row(align=True)
+        row.operator("mmd_tools.convert_bone_morph_to_vertex_morph", text="Convert To Vertex Morph", icon="SHAPEKEY_DATA")
+
         col.label(text=bpy.app.translations.pgettext_iface("Bone Offsets (%d)") % len(morph.data))
         data = self._template_morph_offset_list(col, morph, "MMD_TOOLS_UL_BoneMorphOffsets")
         if data is None:

--- a/mmd_tools/panels/sidebar/morph_tools.py
+++ b/mmd_tools/panels/sidebar/morph_tools.py
@@ -59,7 +59,7 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
             )
             row.label(text="Morph Settings")
             if mmd_root.morph_panel_show_settings:
-                draw_func = getattr(self, "_draw_%s_data" % morph_type[:-7], None)
+                draw_func = getattr(self, f"_draw_{morph_type[:-7]}_data", None)
                 if draw_func:
                     draw_func(context, rig, col, morph)
 

--- a/mmd_tools/panels/sidebar/morph_tools.py
+++ b/mmd_tools/panels/sidebar/morph_tools.py
@@ -223,7 +223,7 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
 
     def _draw_group_data(self, context, rig, col, morph):
         row = col.row(align=True)
-        row.operator("mmd_tools.convert_group_morph_to_vertex_morph", text="Merge Group Vertex Morphs", icon="SHAPEKEY_DATA")
+        row.operator("mmd_tools.convert_group_morph_to_vertex_morph", text="Convert To Vertex Morph", icon="SHAPEKEY_DATA")
 
         col.label(text=bpy.app.translations.pgettext_iface("Group Offsets (%d)") % len(morph.data))
         item = self._template_morph_offset_list(col, morph, "MMD_TOOLS_UL_GroupMorphOffsets")

--- a/mmd_tools/preferences.py
+++ b/mmd_tools/preferences.py
@@ -13,8 +13,7 @@ def get_preset_items_for_operator(operator_bl_idname):
         from .operators import fileio
 
         presets = fileio.get_available_presets(operator_bl_idname)
-        for preset in presets:
-            items.append((preset, preset, f"Use preset: {preset}"))
+        items.extend((preset, preset, f"Use preset: {preset}") for preset in presets)
     except Exception:
         pass
     return items

--- a/mmd_tools/properties/morph.py
+++ b/mmd_tools/properties/morph.py
@@ -17,7 +17,7 @@ def _morph_base_get_name(prop: "_MorphBase") -> str:
 def _morph_base_set_name(prop: "_MorphBase", value: str):
     mmd_root = prop.id_data.mmd_root
     # morph_type = mmd_root.active_morph_type
-    morph_type = "%s_morphs" % prop.bl_rna.identifier[:-5].lower()
+    morph_type = f"{prop.bl_rna.identifier[:-5].lower()}_morphs"
     # assert(prop.bl_rna.identifier.endswith('Morph'))
     # logging.debug('_set_name: %s %s %s', prop, value, morph_type)
     prop_name = prop.get("name", None)

--- a/mmd_tools/properties/pose_bone.py
+++ b/mmd_tools/properties/pose_bone.py
@@ -239,7 +239,7 @@ class MMDBone(bpy.types.PropertyGroup):
                 description="MMD IK toggle is used to import/export animation of IK on-off",
                 update=_pose_bone_update_mmd_ik_toggle,
                 default=True,
-            )
+            ),
         )
 
     @staticmethod

--- a/mmd_tools/properties/pose_bone.py
+++ b/mmd_tools/properties/pose_bone.py
@@ -252,7 +252,7 @@ class MMDBone(bpy.types.PropertyGroup):
 
 def _pose_bone_update_mmd_ik_toggle(prop: bpy.types.PoseBone, _context):
     v = prop.mmd_ik_toggle
-    armature_object = cast(bpy.types.Object, prop.id_data)
+    armature_object = cast("bpy.types.Object", prop.id_data)
     for b in armature_object.pose.bones:
         for c in b.constraints:
             if c.type == "IK" and c.subtarget == prop.name:

--- a/mmd_tools/properties/root.py
+++ b/mmd_tools/properties/root.py
@@ -550,7 +550,7 @@ class MMDRoot(bpy.types.PropertyGroup):
                     ("SPRING_CONSTRAINT", "Spring Constraint", "", 53),
                     ("SPRING_GOAL", "Spring Goal", "", 54),
                 ],
-            )
+            ),
         )
         bpy.types.Object.mmd_root = patch_library_overridable(bpy.props.PointerProperty(type=MMDRoot))
 
@@ -563,7 +563,7 @@ class MMDRoot(bpy.types.PropertyGroup):
                     "ANIMATABLE",
                     "LIBRARY_EDITABLE",
                 },
-            )
+            ),
         )
         bpy.types.Object.hide = patch_library_overridable(
             bpy.props.BoolProperty(
@@ -574,7 +574,7 @@ class MMDRoot(bpy.types.PropertyGroup):
                     "ANIMATABLE",
                     "LIBRARY_EDITABLE",
                 },
-            )
+            ),
         )
 
     @staticmethod

--- a/mmd_tools/properties/root.py
+++ b/mmd_tools/properties/root.py
@@ -163,7 +163,7 @@ def _getVisibilityOfMMDRigArmature(prop: "MMDRoot"):
     if prop.id_data.mmd_type != "ROOT":
         return False
     arm = FnModel.find_armature_object(prop.id_data)
-    return arm and not arm.hide_get()
+    return arm is not None and not arm.hide_get()
 
 
 def _setActiveRigidbodyObject(prop: "MMDRoot", v: int):

--- a/mmd_tools/translations.py
+++ b/mmd_tools/translations.py
@@ -433,7 +433,7 @@ class DictionaryEnum:
         items.append(("INTERNAL", "Internal Dictionary", "The dictionary defined in " + __name__, len(items)))
 
         for txt_name in sorted(x.name for x in bpy.data.texts if x.name.lower().endswith(".csv")):
-            items.append((txt_name, txt_name, "bpy.data.texts['%s']" % txt_name, "TEXT", len(items)))
+            items.append((txt_name, txt_name, f"bpy.data.texts['{txt_name}']", "TEXT", len(items)))
 
         folder = FnContext.get_addon_preferences_attribute(context, "dictionary_folder", "")
         if os.path.isdir(folder):

--- a/mmd_tools/translations.py
+++ b/mmd_tools/translations.py
@@ -406,13 +406,13 @@ class MMDTranslator:
     def load(self, filepath=None):
         filepath = filepath or self.default_csv_filepath()
         logging.info("Loading csv file:\t%s", filepath)
-        with open(filepath, "rt", encoding="utf-8", newline="") as csvfile:
+        with open(filepath, encoding="utf-8", newline="") as csvfile:
             self.load_from_stream(csvfile)
 
     def save(self, filepath=None):
         filepath = filepath or self.default_csv_filepath()
         logging.info("Saving csv file:\t%s", filepath)
-        with open(filepath, "wt", encoding="utf-8", newline="") as csvfile:
+        with open(filepath, "w", encoding="utf-8", newline="") as csvfile:
             self.save_to_stream(csvfile)
 
 

--- a/mmd_tools/utils.py
+++ b/mmd_tools/utils.py
@@ -61,8 +61,8 @@ def selectSingleBone(context, armature, bone_name, reset_pose=False):
             i.hide = False
 
 
-__CONVERT_NAME_TO_L_REGEXP = re.compile("^(.*)左(.*)$")
-__CONVERT_NAME_TO_R_REGEXP = re.compile("^(.*)右(.*)$")
+__CONVERT_NAME_TO_L_REGEXP = re.compile(r"^(.*)左(.*)$")
+__CONVERT_NAME_TO_R_REGEXP = re.compile(r"^(.*)右(.*)$")
 
 
 # 日本語で左右を命名されている名前をblender方式のL(R)に変更する

--- a/mmd_tools/utils.py
+++ b/mmd_tools/utils.py
@@ -132,10 +132,7 @@ def separateByMaterials(meshObj: bpy.types.Object):
 
 
 def clearUnusedMeshes():
-    meshes_to_delete = []
-    for mesh in bpy.data.meshes:
-        if mesh.users == 0:
-            meshes_to_delete.append(mesh)
+    meshes_to_delete = [mesh for mesh in bpy.data.meshes if mesh.users == 0]
 
     for mesh in meshes_to_delete:
         bpy.data.meshes.remove(mesh)

--- a/tests/all_test_runner.py
+++ b/tests/all_test_runner.py
@@ -147,12 +147,16 @@ def run_test(blender_path, test_script, current_test_num, total_tests, previous_
         # Return the final progress for this test
         final_progress = current_test_num / total_tests
 
-        # Check if the test passed
-        # Look for "OK" indicating all tests passed, or check for absence of FAILED/ERROR
-        if "OK" in result.stdout or (result.returncode == 0 and "FAILED" not in result.stdout and "ERROR" not in result.stdout):
+        # Check if the test passed - specifically for unittest output
+        output = result.stdout + result.stderr
+        success_indicators = ["OK"]
+        failure_indicators = ["FAILED", "ERROR", "failures=", "errors=", "skipped="]
+
+        has_success = any(indicator in output for indicator in success_indicators)
+        has_failure = any(indicator in output for indicator in failure_indicators)
+
+        if result.returncode == 0 and has_success and not has_failure:
             return True, "", elapsed_str, final_progress
-        # We no longer extract the detailed error message
-        # Just indicate that the test failed
         return False, "Test failed", elapsed_str, final_progress
 
     except Exception:

--- a/tests/all_test_runner.py
+++ b/tests/all_test_runner.py
@@ -126,8 +126,7 @@ def run_test(blender_path, test_script, current_test_num, total_tests, previous_
         # Run the test
         result = subprocess.run(
             cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
             encoding="utf-8",
             errors="replace",  # Handle Unicode decode errors gracefully
@@ -199,7 +198,7 @@ def run_all_tests():
     # If blender_path is just "blender", check if it's in PATH by running a simple command
     if blender_path == "blender":
         try:
-            subprocess.run([blender_path, "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+            subprocess.run([blender_path, "--version"], capture_output=True, check=False)
         except FileNotFoundError:
             print("Error: 'blender' executable not found in PATH.")
             print("Please either:")

--- a/tests/all_test_runner.py
+++ b/tests/all_test_runner.py
@@ -129,7 +129,7 @@ def run_test(blender_path, test_script, current_test_num, total_tests, previous_
             capture_output=True,
             text=True,
             encoding="utf-8",
-            errors="replace",  # Handle Unicode decode errors gracefully
+            errors="replace",
             check=True,
         )
 
@@ -148,8 +148,8 @@ def run_test(blender_path, test_script, current_test_num, total_tests, previous_
 
         # Check if the test passed - specifically for unittest output
         output = result.stdout + result.stderr
-        success_indicators = ["OK"]
-        failure_indicators = ["FAILED", "ERROR", "failures=", "errors=", "skipped="]
+        success_indicators = {"OK"}
+        failure_indicators = {"FAIL\n", "FAIL:", "ERROR\n", "ERROR:", "skipped", "FAILED", "failures=", "errors=", "skipped="}
 
         has_success = any(indicator in output for indicator in success_indicators)
         has_failure = any(indicator in output for indicator in failure_indicators)

--- a/tests/all_test_runner.py
+++ b/tests/all_test_runner.py
@@ -179,7 +179,7 @@ def print_summary_progress(iteration, total):
     """Print a simple progress bar for the overall progress"""
     progress_percent = iteration / float(total)
 
-    percent = ("{0:.1f}").format(100 * progress_percent)
+    percent = (f"{100 * progress_percent:.1f}")
     length = 30
     filled_length = int(length * progress_percent)
     bar = "█" * filled_length + "-" * (length - filled_length)

--- a/tests/all_test_runner.py
+++ b/tests/all_test_runner.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import glob
 import multiprocessing
 import os

--- a/tests/all_test_runner.py
+++ b/tests/all_test_runner.py
@@ -128,6 +128,7 @@ def run_test(blender_path, test_script, current_test_num, total_tests, previous_
             text=True,
             encoding="utf-8",
             errors="replace",  # Handle Unicode decode errors gracefully
+            check=True,
         )
 
         # Calculate total execution time

--- a/tests/test_bone.py
+++ b/tests/test_bone.py
@@ -106,14 +106,6 @@ class TestBone(unittest.TestCase):
 
         return armature_object
 
-    def __vector_error(self, vec0, vec1):
-        """Calculate vector difference"""
-        return (Vector(vec0) - Vector(vec1)).length
-
-    def __axis_error(self, axis0, axis1):
-        """Calculate axis difference"""
-        return (Vector(axis0).normalized() - Vector(axis1).normalized()).length
-
     # ********************************************
     # Bone ID Tests
     # ********************************************

--- a/tests/test_bone.py
+++ b/tests/test_bone.py
@@ -10,8 +10,8 @@ import unittest
 import bpy
 
 # Import the modules to test
-from bl_ext.user_default.mmd_tools.core.bone import FnBone, MigrationFnBone
-from bl_ext.user_default.mmd_tools.core.model import FnModel
+from bl_ext.blender_org.mmd_tools.core.bone import FnBone, MigrationFnBone
+from bl_ext.blender_org.mmd_tools.core.model import FnModel
 from mathutils import Vector
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -55,7 +55,7 @@ class TestBone(unittest.TestCase):
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
 
     def __create_test_armature(self):
         """Create a test armature with some bones for testing"""

--- a/tests/test_bone.py
+++ b/tests/test_bone.py
@@ -33,11 +33,9 @@ class TestBone(unittest.TestCase):
                     shutil.rmtree(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
-        # logger.setLevel('DEBUG')
-        # logger.setLevel('INFO')
 
         # Start with a clean Blender scene
         bpy.ops.wm.read_homefile(use_empty=True)

--- a/tests/test_bone.py
+++ b/tests/test_bone.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import math
 import os

--- a/tests/test_bone_order.py
+++ b/tests/test_bone_order.py
@@ -13,7 +13,7 @@ class TestBoneOrder(unittest.TestCase):
     """Test suite for bone order operations and bone ID management"""
 
     def setUp(self):
-        """Set up test environment with MMD model and bones"""
+        """Set up testing environment"""
         # Clear existing mesh objects to start clean
         bpy.ops.object.select_all(action="SELECT")
         bpy.ops.object.delete(use_global=False)

--- a/tests/test_bone_order.py
+++ b/tests/test_bone_order.py
@@ -86,7 +86,7 @@ class TestBoneOrder(unittest.TestCase):
 
                 # Set some bones with additional transform properties for testing
                 # Use bone names that exist and find their IDs after fix
-                if bone_name in ["left_arm", "right_arm"]:
+                if bone_name in {"left_arm", "right_arm"}:
                     pose_bone.mmd_bone.has_additional_rotation = True
                     pose_bone.mmd_bone.additional_transform_bone = "upper_body"
                     # Note: additional_transform_bone_id will be set properly after fix_bone_order

--- a/tests/test_bone_order.py
+++ b/tests/test_bone_order.py
@@ -4,8 +4,8 @@
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core.model import FnModel, Model
-from bl_ext.user_default.mmd_tools.panels.sidebar.bone_order import MMD_TOOLS_UL_ModelBones
+from bl_ext.blender_org.mmd_tools.core.model import FnModel, Model
+from bl_ext.blender_org.mmd_tools.panels.sidebar.bone_order import MMD_TOOLS_UL_ModelBones
 from mathutils import Vector
 
 

--- a/tests/test_bone_order.py
+++ b/tests/test_bone_order.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import unittest
 
 import bpy

--- a/tests/test_camera_system.py
+++ b/tests/test_camera_system.py
@@ -8,7 +8,7 @@ import shutil
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core.camera import FnCamera, MMDCamera
+from bl_ext.blender_org.mmd_tools.core.camera import FnCamera, MMDCamera
 from mathutils import Euler, Vector
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -48,7 +48,7 @@ class TestCameraSystem(unittest.TestCase):
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
 
     def __vector_error(self, vec0, vec1):
         """Calculate vector difference error"""

--- a/tests/test_camera_system.py
+++ b/tests/test_camera_system.py
@@ -30,7 +30,7 @@ class TestCameraSystem(unittest.TestCase):
                     shutil.rmtree(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
         # Clear all objects from scene

--- a/tests/test_camera_system.py
+++ b/tests/test_camera_system.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import math
 import os

--- a/tests/test_display_system.py
+++ b/tests/test_display_system.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import os
 import shutil

--- a/tests/test_display_system.py
+++ b/tests/test_display_system.py
@@ -7,8 +7,8 @@ import shutil
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core.model import Model
-from bl_ext.user_default.mmd_tools.utils import ItemOp
+from bl_ext.blender_org.mmd_tools.core.model import Model
+from bl_ext.blender_org.mmd_tools.utils import ItemOp
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -58,7 +58,7 @@ class TestDisplaySystem(unittest.TestCase):
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
 
     def __create_test_model(self):
         """Create a test MMD model with basic structure"""

--- a/tests/test_display_system.py
+++ b/tests/test_display_system.py
@@ -29,11 +29,9 @@ class TestDisplaySystem(unittest.TestCase):
                     shutil.rmtree(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
-        # logger.setLevel('DEBUG')
-        # logger.setLevel('INFO')
 
         # Clear existing scene
         bpy.ops.wm.read_homefile(use_empty=True)

--- a/tests/test_fileio_operators.py
+++ b/tests/test_fileio_operators.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import os
 import shutil

--- a/tests/test_fileio_operators.py
+++ b/tests/test_fileio_operators.py
@@ -55,7 +55,7 @@ class TestFileIoOperators(unittest.TestCase):
         """
         input_blend = os.path.join(SAMPLES_DIR, "blends", "shy_cube", "shy_cube.blend")
         if not os.path.isfile(input_blend):
-            self.fail("required sample file %s not found. Please download it" % input_blend)
+            self.fail(f"required sample file {input_blend} not found. Please download it")
         output_pmx = os.path.join(TESTS_DIR, "output", "shy_cube.pmx")
         bpy.ops.wm.open_mainfile(filepath=input_blend)
         root = Model.findRoot(self.context.active_object)

--- a/tests/test_fileio_operators.py
+++ b/tests/test_fileio_operators.py
@@ -30,7 +30,7 @@ class TestFileIoOperators(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
 

--- a/tests/test_fileio_operators.py
+++ b/tests/test_fileio_operators.py
@@ -7,8 +7,8 @@ import shutil
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core import pmx
-from bl_ext.user_default.mmd_tools.core.model import Model
+from bl_ext.blender_org.mmd_tools.core import pmx
+from bl_ext.blender_org.mmd_tools.core.model import Model
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 SAMPLES_DIR = os.path.join(os.path.dirname(TESTS_DIR), "samples")

--- a/tests/test_lamp_system.py
+++ b/tests/test_lamp_system.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import os
 import shutil

--- a/tests/test_lamp_system.py
+++ b/tests/test_lamp_system.py
@@ -9,9 +9,9 @@ import unittest
 import bpy
 
 # Import the lamp system components
-from bl_ext.user_default.mmd_tools.core.lamp import MMDLamp
-from bl_ext.user_default.mmd_tools.operators.lamp import ConvertToMMDLamp
-from bl_ext.user_default.mmd_tools.panels.prop_lamp import MMDLampPanel
+from bl_ext.blender_org.mmd_tools.core.lamp import MMDLamp
+from bl_ext.blender_org.mmd_tools.operators.lamp import ConvertToMMDLamp
+from bl_ext.blender_org.mmd_tools.panels.prop_lamp import MMDLampPanel
 from mathutils import Vector
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -60,7 +60,7 @@ class TestLampSystem(unittest.TestCase):
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
 
     def __create_lamp_object(self, name="TestLamp", lamp_type="SUN", location=(0, 0, 0)):
         """Create a lamp object for testing"""

--- a/tests/test_lamp_system.py
+++ b/tests/test_lamp_system.py
@@ -33,11 +33,9 @@ class TestLampSystem(unittest.TestCase):
                     shutil.rmtree(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
-        # logger.setLevel('DEBUG')
-        # logger.setLevel('INFO')
 
         # Clear all mesh objects
         bpy.ops.wm.read_homefile(use_empty=True)

--- a/tests/test_material_system.py
+++ b/tests/test_material_system.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import gc
 import logging
 import os

--- a/tests/test_material_system.py
+++ b/tests/test_material_system.py
@@ -8,10 +8,10 @@ import shutil
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core.exceptions import MaterialNotFoundError
-from bl_ext.user_default.mmd_tools.core.material import FnMaterial, MigrationFnMaterial
-from bl_ext.user_default.mmd_tools.core.model import Model
-from bl_ext.user_default.mmd_tools.panels.prop_material import MMDMaterialPanel, MMDTexturePanel
+from bl_ext.blender_org.mmd_tools.core.exceptions import MaterialNotFoundError
+from bl_ext.blender_org.mmd_tools.core.material import FnMaterial, MigrationFnMaterial
+from bl_ext.blender_org.mmd_tools.core.model import Model
+from bl_ext.blender_org.mmd_tools.panels.prop_material import MMDMaterialPanel, MMDTexturePanel
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 SAMPLES_DIR = os.path.join(os.path.dirname(TESTS_DIR), "samples")
@@ -107,9 +107,9 @@ class TestMaterialSystem(unittest.TestCase):
         """Make sure mmd_tools addon is enabled"""
         bpy.ops.wm.read_homefile(use_empty=True)
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
-        if not pref.addons.get("bl_ext.user_default.mmd_tools", None):
+        if not pref.addons.get("bl_ext.blender_org.mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
 
     # ********************************************
     # Helper Functions

--- a/tests/test_material_system.py
+++ b/tests/test_material_system.py
@@ -635,9 +635,9 @@ class TestMaterialSystem(unittest.TestCase):
         self.assertAlmostEqual(mmd_mat2.ambient_color[1], expected_ambient2[1], places=6, msg="Material2 ambient G should be half of BSDF-set diffuse G")
         self.assertAlmostEqual(mmd_mat2.ambient_color[2], expected_ambient2[2], places=6, msg="Material2 ambient B should be half of BSDF-set diffuse B")
 
-        print("   - Converted diffuse color (with texture): ({:.2f}, {:.2f}, {:.2f})".format(*mmd_mat.diffuse_color))
-        print("   - Converted diffuse color (no texture): ({:.2f}, {:.2f}, {:.2f})".format(*mmd_mat2.diffuse_color))
-        print("   - Calculated ambient color: ({:.2f}, {:.2f}, {:.2f})".format(*mmd_mat.ambient_color))
+        print(f"   - Converted diffuse color (with texture): {mmd_mat.diffuse_color}")
+        print(f"   - Converted diffuse color (no texture): {mmd_mat2.diffuse_color}")
+        print(f"   - Calculated ambient color: {mmd_mat.ambient_color}")
         print(f"   - Calculated shininess: {mmd_mat.shininess:.1f}")
         print("✓ Convert to MMD material test passed")
 

--- a/tests/test_material_system.py
+++ b/tests/test_material_system.py
@@ -33,7 +33,7 @@ class TestMaterialSystem(unittest.TestCase):
                     shutil.rmtree(item_fp)
 
     def setUp(self):
-        """Start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
 

--- a/tests/test_material_system.py
+++ b/tests/test_material_system.py
@@ -638,7 +638,7 @@ class TestMaterialSystem(unittest.TestCase):
         print("   - Converted diffuse color (with texture): ({:.2f}, {:.2f}, {:.2f})".format(*mmd_mat.diffuse_color))
         print("   - Converted diffuse color (no texture): ({:.2f}, {:.2f}, {:.2f})".format(*mmd_mat2.diffuse_color))
         print("   - Calculated ambient color: ({:.2f}, {:.2f}, {:.2f})".format(*mmd_mat.ambient_color))
-        print("   - Calculated shininess: {:.1f}".format(mmd_mat.shininess))
+        print(f"   - Calculated shininess: {mmd_mat.shininess:.1f}")
         print("✓ Convert to MMD material test passed")
 
     # ********************************************

--- a/tests/test_model_debug.py
+++ b/tests/test_model_debug.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import os
 import unittest

--- a/tests/test_model_debug.py
+++ b/tests/test_model_debug.py
@@ -6,7 +6,7 @@ import os
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core.model import FnModel, Model
+from bl_ext.blender_org.mmd_tools.core.model import FnModel, Model
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 SAMPLES_DIR = os.path.join(os.path.dirname(TESTS_DIR), "samples")
@@ -30,7 +30,7 @@ class TestModelDebug(unittest.TestCase):
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")  # make sure addon 'mmd_tools' is enabled
+            addon_enable(module="bl_ext.blender_org.mmd_tools")  # make sure addon 'mmd_tools' is enabled
 
         # Create test model
         self.model_name = "Test Model"

--- a/tests/test_model_edit.py
+++ b/tests/test_model_edit.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import os
 import shutil

--- a/tests/test_model_edit.py
+++ b/tests/test_model_edit.py
@@ -446,7 +446,6 @@ class TestModelEdit(unittest.TestCase):
             # First, collect the objects to be removed
             objects_to_remove = []
             for obj in bpy.data.objects:
-                print("??????????????????????")
                 if obj.type == "ARMATURE" and obj not in {first_model_arm, second_model_arm_with_head}:
                     objects_to_remove.append(obj)
                 elif obj.mmd_type == "ROOT" and obj not in {first_model_root, second_model_root}:

--- a/tests/test_model_edit.py
+++ b/tests/test_model_edit.py
@@ -323,8 +323,8 @@ class TestModelEdit(unittest.TestCase):
             armatures_with_bone_info = []
             for arm in all_armatures:
                 # Count bones with specific names
-                head_bones = [b for b in arm.pose.bones if b.name in ["頭", "head", "Head"]]
-                neck_bones = [b for b in arm.pose.bones if b.name in ["首", "neck", "Neck"]]
+                head_bones = [b for b in arm.pose.bones if b.name in {"頭", "head", "Head"}]
+                neck_bones = [b for b in arm.pose.bones if b.name in {"首", "neck", "Neck"}]
 
                 print(f"Armature: {arm.name}")
                 print(f"    Total bones: {len(arm.pose.bones)}")
@@ -453,9 +453,10 @@ class TestModelEdit(unittest.TestCase):
             # First, collect the objects to be removed
             objects_to_remove = []
             for obj in bpy.data.objects:
-                if obj.type == "ARMATURE" and obj not in (first_model_arm, second_model_arm_with_head):
+                print("??????????????????????")
+                if obj.type == "ARMATURE" and obj not in {first_model_arm, second_model_arm_with_head}:
                     objects_to_remove.append(obj)
-                elif obj.mmd_type == "ROOT" and obj not in (first_model_root, second_model_root):
+                elif obj.mmd_type == "ROOT" and obj not in {first_model_root, second_model_root}:
                     objects_to_remove.append(obj)
             # Then remove them in a separate loop
             for obj in objects_to_remove:
@@ -470,8 +471,8 @@ class TestModelEdit(unittest.TestCase):
             context.view_layer.objects.active = first_model_arm
 
             for arm in [first_model_arm, second_model_arm_with_head]:
-                head_bones = [b for b in arm.pose.bones if b.name in ["頭", "head", "Head"]]
-                neck_bones = [b for b in arm.pose.bones if b.name in ["首", "neck", "Neck"]]
+                head_bones = [b for b in arm.pose.bones if b.name in {"頭", "head", "Head"}]
+                neck_bones = [b for b in arm.pose.bones if b.name in {"首", "neck", "Neck"}]
                 print(f"Armature: {arm.name}")
                 print(f"    Total bones: {len(arm.pose.bones)}")
                 print(f"    Has head bones: {[b.name for b in head_bones]}")
@@ -519,8 +520,8 @@ class TestModelEdit(unittest.TestCase):
             joined_model_armature = FnModel.find_armature_object(joined_model_root)
 
             arm = joined_model_armature
-            head_bones = [b for b in arm.pose.bones if b.name in ["頭", "head", "Head"]]
-            neck_bones = [b for b in arm.pose.bones if b.name in ["首", "neck", "Neck"]]
+            head_bones = [b for b in arm.pose.bones if b.name in {"頭", "head", "Head"}]
+            neck_bones = [b for b in arm.pose.bones if b.name in {"首", "neck", "Neck"}]
             print(f"Armature: {arm.name}")
             print(f"    Total bones: {len(arm.pose.bones)}")
             print(f"    Has head bones: {[b.name for b in head_bones]}")

--- a/tests/test_model_edit.py
+++ b/tests/test_model_edit.py
@@ -64,9 +64,7 @@ class TestModelEdit(unittest.TestCase):
         for file_type in file_types:
             file_ext = "." + file_type
             for root, dirs, files in os.walk(os.path.join(SAMPLES_DIR, file_type)):
-                for name in files:
-                    if name.lower().endswith(file_ext):
-                        ret.append(os.path.join(root, name))
+                ret.extend(os.path.join(root, name) for name in files if name.lower().endswith(file_ext))
         return ret
 
     def __enable_mmd_tools(self):
@@ -248,10 +246,7 @@ class TestModelEdit(unittest.TestCase):
             self.assertEqual(len(pmx_models), 2, "Failed to import two models")
 
             # Keep track of all model roots in our collection before separation
-            existing_roots = []
-            for obj in test_collection.objects:
-                if obj.mmd_type == "ROOT":
-                    existing_roots.append(obj)
+            existing_roots = [obj for obj in test_collection.objects if obj.mmd_type == "ROOT"]
 
             print(f"\nBefore separation - Model roots: {[root.name for root in existing_roots]}")
 
@@ -304,10 +299,7 @@ class TestModelEdit(unittest.TestCase):
                         self.__move_children_to_collection(obj, test_collection)
 
             # After separation, find all the armatures and roots in our collection
-            all_roots = []
-            for obj in test_collection.objects:
-                if obj.mmd_type == "ROOT":
-                    all_roots.append(obj)
+            all_roots = [obj for obj in test_collection.objects if obj.mmd_type == "ROOT"]
 
             all_armatures = []
             for obj in bpy.data.objects:
@@ -505,10 +497,7 @@ class TestModelEdit(unittest.TestCase):
             bpy.ops.object.mode_set(mode="OBJECT")
 
             # Check the result - get all roots in our collection
-            final_roots = []
-            for obj in test_collection.objects:
-                if obj.mmd_type == "ROOT":
-                    final_roots.append(obj)
+            final_roots = [obj for obj in test_collection.objects if obj.mmd_type == "ROOT"]
 
             print(f"\nAfter joining - Model roots: {[root.name for root in final_roots]}")
 

--- a/tests/test_model_edit.py
+++ b/tests/test_model_edit.py
@@ -9,9 +9,9 @@ import traceback
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core import pmx
-from bl_ext.user_default.mmd_tools.core.model import FnModel
-from bl_ext.user_default.mmd_tools.core.pmx.importer import PMXImporter
+from bl_ext.blender_org.mmd_tools.core import pmx
+from bl_ext.blender_org.mmd_tools.core.model import FnModel
+from bl_ext.blender_org.mmd_tools.core.pmx.importer import PMXImporter
 
 context = bpy.context
 
@@ -72,7 +72,7 @@ class TestModelEdit(unittest.TestCase):
         pref = getattr(context, "preferences", None) or context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")  # make sure addon 'mmd_tools' is enabled
+            addon_enable(module="bl_ext.blender_org.mmd_tools")  # make sure addon 'mmd_tools' is enabled
 
     def __is_object_in_collection(self, obj, collection):
         """Safely check if an object is in a collection"""

--- a/tests/test_model_edit.py
+++ b/tests/test_model_edit.py
@@ -37,6 +37,7 @@ class TestModelEdit(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
 

--- a/tests/test_model_edit.py
+++ b/tests/test_model_edit.py
@@ -450,9 +450,9 @@ class TestModelEdit(unittest.TestCase):
             # First, collect the objects to be removed
             objects_to_remove = []
             for obj in bpy.data.objects:
-                if obj.type == "ARMATURE" and obj != first_model_arm and obj != second_model_arm_with_head:
+                if obj.type == "ARMATURE" and obj not in (first_model_arm, second_model_arm_with_head):
                     objects_to_remove.append(obj)
-                elif obj.mmd_type == "ROOT" and obj != first_model_root and obj != second_model_root:
+                elif obj.mmd_type == "ROOT" and obj not in (first_model_root, second_model_root):
                     objects_to_remove.append(obj)
             # Then remove them in a separate loop
             for obj in objects_to_remove:

--- a/tests/test_model_management.py
+++ b/tests/test_model_management.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import os
 import shutil

--- a/tests/test_model_management.py
+++ b/tests/test_model_management.py
@@ -8,8 +8,8 @@ import unittest
 
 import bmesh
 import bpy
-from bl_ext.user_default.mmd_tools.core.model import FnModel, Model
-from bl_ext.user_default.mmd_tools.core.sdef import FnSDEF
+from bl_ext.blender_org.mmd_tools.core.model import FnModel, Model
+from bl_ext.blender_org.mmd_tools.core.sdef import FnSDEF
 from mathutils import Vector
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -46,7 +46,7 @@ class TestModelManagement(unittest.TestCase):
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")  # make sure addon 'mmd_tools' is enabled
+            addon_enable(module="bl_ext.blender_org.mmd_tools")  # make sure addon 'mmd_tools' is enabled
 
     def __list_sample_files(self, file_types):
         ret = []

--- a/tests/test_model_management.py
+++ b/tests/test_model_management.py
@@ -31,11 +31,9 @@ class TestModelManagement(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
-        # logger.setLevel('DEBUG')
-        # logger.setLevel('INFO')
 
     # ********************************************
     # Utils

--- a/tests/test_model_management.py
+++ b/tests/test_model_management.py
@@ -53,9 +53,7 @@ class TestModelManagement(unittest.TestCase):
         for file_type in file_types:
             file_ext = "." + file_type
             for root, dirs, files in os.walk(os.path.join(SAMPLES_DIR, file_type)):
-                for name in files:
-                    if name.lower().endswith(file_ext):
-                        ret.append(os.path.join(root, name))
+                ret.extend(os.path.join(root, name) for name in files if name.lower().endswith(file_ext))
         return ret
 
     def __create_mesh_geometry(self, mesh_data, vertices, faces):

--- a/tests/test_model_operators.py
+++ b/tests/test_model_operators.py
@@ -23,7 +23,7 @@ EXP_FRAME = "\u8868\u60c5"
 class ModelOperatorsTest(unittest.TestCase):
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         # Ensure active object exists (user may have deleted the default cube)
         if not bpy.context.active_object:
             bpy.ops.mesh.primitive_cube_add()

--- a/tests/test_model_operators.py
+++ b/tests/test_model_operators.py
@@ -4,7 +4,7 @@
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core.model import Model
+from bl_ext.blender_org.mmd_tools.core.model import Model
 
 # Usage: blender --background -noaudio --python tests/test_model_operators.py -- --verbose
 

--- a/tests/test_model_operators.py
+++ b/tests/test_model_operators.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import unittest
 
 import bpy

--- a/tests/test_morph_system.py
+++ b/tests/test_morph_system.py
@@ -90,9 +90,7 @@ class TestMorphSystem(unittest.TestCase):
         for file_type in file_types:
             file_ext = "." + file_type
             for root, dirs, files in os.walk(os.path.join(SAMPLES_DIR, file_type)):
-                for name in files:
-                    if name.lower().endswith(file_ext):
-                        ret.append(os.path.join(root, name))
+                ret.extend(os.path.join(root, name) for name in files if name.lower().endswith(file_ext))
         return ret
 
     # ********************************************

--- a/tests/test_morph_system.py
+++ b/tests/test_morph_system.py
@@ -9,8 +9,8 @@ import unittest
 from collections import namedtuple
 
 import bpy
-from bl_ext.user_default.mmd_tools.core.model import Model
-from bl_ext.user_default.mmd_tools.core.morph import FnMorph, MigrationFnMorph
+from bl_ext.blender_org.mmd_tools.core.model import Model
+from bl_ext.blender_org.mmd_tools.core.morph import FnMorph, MigrationFnMorph
 from mathutils import Quaternion, Vector
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -49,7 +49,7 @@ class TestMorphSystem(unittest.TestCase):
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
 
     def __create_test_model(self, name="TestModel"):
         """Create a simple test model with armature and mesh"""

--- a/tests/test_morph_system.py
+++ b/tests/test_morph_system.py
@@ -32,7 +32,7 @@ class TestMorphSystem(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
 

--- a/tests/test_morph_system.py
+++ b/tests/test_morph_system.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import math
 import os

--- a/tests/test_pmx_exporter.py
+++ b/tests/test_pmx_exporter.py
@@ -428,7 +428,7 @@ class TestPmxExporter(unittest.TestCase):
         result = result_table.get(pmx.VertexMorph, [])
         self.assertEqual(len(source), len(result))
         for m0, m1 in zip(source, result, strict=False):
-            msg = "VertexMorph %s" % m0.name
+            msg = f"VertexMorph {m0.name}"
             self.assertEqual(m0.name, m1.name, msg)
             self.assertEqual(m0.name_e, m1.name_e, msg)
             self.assertEqual(m0.category, m1.category, msg)
@@ -441,7 +441,7 @@ class TestPmxExporter(unittest.TestCase):
         result = result_table.get(pmx.UVMorph, [])
         self.assertEqual(len(source), len(result))
         for m0, m1 in zip(source, result, strict=False):
-            msg = "UVMorph %s" % m0.name
+            msg = f"UVMorph {m0.name}"
             self.assertEqual(m0.name, m1.name, msg)
             self.assertEqual(m0.name_e, m1.name_e, msg)
             self.assertEqual(m0.category, m1.category, msg)
@@ -459,7 +459,7 @@ class TestPmxExporter(unittest.TestCase):
         result = result_table.get(pmx.BoneMorph, [])
         self.assertEqual(len(source), len(result))
         for m0, m1 in zip(source, result, strict=False):
-            msg = "BoneMorph %s" % m0.name
+            msg = f"BoneMorph {m0.name}"
             self.assertEqual(m0.name, m1.name, msg)
             self.assertEqual(m0.name_e, m1.name_e, msg)
             self.assertEqual(m0.category, m1.category, msg)
@@ -483,7 +483,7 @@ class TestPmxExporter(unittest.TestCase):
         result = result_table.get(pmx.MaterialMorph, [])
         self.assertEqual(len(source), len(result))
         for m0, m1 in zip(source, result, strict=False):
-            msg = "MaterialMorph %s" % m0.name
+            msg = f"MaterialMorph {m0.name}"
             self.assertEqual(m0.name, m1.name, msg)
             self.assertEqual(m0.name_e, m1.name_e, msg)
             self.assertEqual(m0.category, m1.category, msg)
@@ -511,7 +511,7 @@ class TestPmxExporter(unittest.TestCase):
         result = result_table.get(pmx.GroupMorph, [])
         self.assertEqual(len(source), len(result))
         for m0, m1 in zip(source, result, strict=False):
-            msg = "GroupMorph %s" % m0.name
+            msg = f"GroupMorph {m0.name}"
             self.assertEqual(m0.name, m1.name, msg)
             self.assertEqual(m0.name_e, m1.name_e, msg)
             self.assertEqual(m0.category, m1.category, msg)
@@ -607,7 +607,7 @@ class TestPmxExporter(unittest.TestCase):
 
         import_types = self.__get_import_types(check_types)
 
-        print("\n    Check: %s | Import: %s" % (str(check_types), str(import_types)))
+        print(f"\n    Check: {str(check_types)} | Import: {str(import_types)}")
 
         for test_num, filepath in enumerate(input_files):
             print("\n     - %2d/%d | filepath: %s" % (test_num + 1, len(input_files), filepath))
@@ -626,7 +626,7 @@ class TestPmxExporter(unittest.TestCase):
                 # bpy.context.scene.update()
                 bpy.context.scene.frame_set(bpy.context.scene.frame_current)
             except Exception:
-                self.fail("Exception happened during import %s" % filepath)
+                self.fail(f"Exception happened during import {filepath}")
             else:
                 try:
                     output_pmx = os.path.join(TESTS_DIR, "output", "%d.pmx" % test_num)
@@ -640,14 +640,14 @@ class TestPmxExporter(unittest.TestCase):
                         log_level="ERROR",
                     )
                 except Exception:
-                    self.fail("Exception happened during export %s" % output_pmx)
+                    self.fail(f"Exception happened during export {output_pmx}")
                 else:
                     self.assertTrue(os.path.isfile(output_pmx), "File was not created")  # Is this a race condition?
 
                     try:
                         result_model = pmx.load(output_pmx)
                     except Exception:
-                        self.fail("Failed to load output file %s" % output_pmx)
+                        self.fail(f"Failed to load output file {output_pmx}")
 
                     self.__check_pmx_header_info(source_model, result_model, import_types)
 

--- a/tests/test_pmx_exporter.py
+++ b/tests/test_pmx_exporter.py
@@ -581,9 +581,7 @@ class TestPmxExporter(unittest.TestCase):
         for file_type in file_types:
             file_ext = "." + file_type
             for root, dirs, files in os.walk(os.path.join(SAMPLES_DIR, file_type)):
-                for name in files:
-                    if name.lower().endswith(file_ext):
-                        ret.append(os.path.join(root, name))
+                ret.extend(os.path.join(root, name) for name in files if name.lower().endswith(file_ext))
         return ret
 
     def __enable_mmd_tools(self):

--- a/tests/test_pmx_exporter.py
+++ b/tests/test_pmx_exporter.py
@@ -8,9 +8,9 @@ import shutil
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core import pmx
-from bl_ext.user_default.mmd_tools.core.pmd.importer import import_pmd_to_pmx
-from bl_ext.user_default.mmd_tools.core.pmx.importer import PMXImporter
+from bl_ext.blender_org.mmd_tools.core import pmx
+from bl_ext.blender_org.mmd_tools.core.pmd.importer import import_pmd_to_pmx
+from bl_ext.blender_org.mmd_tools.core.pmx.importer import PMXImporter
 from mathutils import Euler, Vector
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -589,7 +589,7 @@ class TestPmxExporter(unittest.TestCase):
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")  # make sure addon 'mmd_tools' is enabled
+            addon_enable(module="bl_ext.blender_org.mmd_tools")  # make sure addon 'mmd_tools' is enabled
 
     def test_pmx_exporter(self):
         input_files = self.__list_sample_files(("pmd", "pmx"))

--- a/tests/test_pmx_exporter.py
+++ b/tests/test_pmx_exporter.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import math
 import os

--- a/tests/test_pmx_exporter.py
+++ b/tests/test_pmx_exporter.py
@@ -32,11 +32,9 @@ class TestPmxExporter(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
-        # logger.setLevel('DEBUG')
-        # logger.setLevel('INFO')
 
     # ********************************************
     # Utils

--- a/tests/test_pmx_exporter_hard.py
+++ b/tests/test_pmx_exporter_hard.py
@@ -8,8 +8,8 @@ import shutil
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core import pmx
-from bl_ext.user_default.mmd_tools.core.pmd.importer import import_pmd_to_pmx
+from bl_ext.blender_org.mmd_tools.core import pmx
+from bl_ext.blender_org.mmd_tools.core.pmd.importer import import_pmd_to_pmx
 from mathutils import Euler, Vector
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -636,7 +636,7 @@ class TestPmxExporter(unittest.TestCase):
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")  # make sure addon 'mmd_tools' is enabled
+            addon_enable(module="bl_ext.blender_org.mmd_tools")  # make sure addon 'mmd_tools' is enabled
 
     def test_pmx_exporter(self):
         """Direct test of PMX file loading/exporting without going through the importer"""

--- a/tests/test_pmx_exporter_hard.py
+++ b/tests/test_pmx_exporter_hard.py
@@ -465,7 +465,7 @@ class TestPmxExporter(unittest.TestCase):
         result = result_table.get(pmx.VertexMorph, [])
         self.assertEqual(len(source), len(result))
         for m0, m1 in zip(source, result, strict=False):
-            msg = "VertexMorph %s" % m0.name
+            msg = f"VertexMorph {m0.name}"
             self.assertEqual(m0.name, m1.name, msg)
             self.assertEqual(m0.name_e, m1.name_e, msg)
             self.assertEqual(m0.category, m1.category, msg)
@@ -488,7 +488,7 @@ class TestPmxExporter(unittest.TestCase):
         result = result_table.get(pmx.UVMorph, [])
         self.assertEqual(len(source), len(result))
         for m0, m1 in zip(source, result, strict=False):
-            msg = "UVMorph %s" % m0.name
+            msg = f"UVMorph {m0.name}"
             self.assertEqual(m0.name, m1.name, msg)
             self.assertEqual(m0.name_e, m1.name_e, msg)
             self.assertEqual(m0.category, m1.category, msg)
@@ -515,7 +515,7 @@ class TestPmxExporter(unittest.TestCase):
         result = result_table.get(pmx.BoneMorph, [])
         self.assertEqual(len(source), len(result))
         for m0, m1 in zip(source, result, strict=False):
-            msg = "BoneMorph %s" % m0.name
+            msg = f"BoneMorph {m0.name}"
             self.assertEqual(m0.name, m1.name, msg)
             self.assertEqual(m0.name_e, m1.name_e, msg)
             self.assertEqual(m0.category, m1.category, msg)
@@ -540,7 +540,7 @@ class TestPmxExporter(unittest.TestCase):
         result = result_table.get(pmx.MaterialMorph, [])
         self.assertEqual(len(source), len(result))
         for m0, m1 in zip(source, result, strict=False):
-            msg = "MaterialMorph %s" % m0.name
+            msg = f"MaterialMorph {m0.name}"
             self.assertEqual(m0.name, m1.name, msg)
             self.assertEqual(m0.name_e, m1.name_e, msg)
             self.assertEqual(m0.category, m1.category, msg)
@@ -572,7 +572,7 @@ class TestPmxExporter(unittest.TestCase):
         result = result_table.get(pmx.GroupMorph, [])
         self.assertEqual(len(source), len(result))
         for m0, m1 in zip(source, result, strict=False):
-            msg = "GroupMorph %s" % m0.name
+            msg = f"GroupMorph {m0.name}"
             self.assertEqual(m0.name, m1.name, msg)
             self.assertEqual(m0.name_e, m1.name_e, msg)
             self.assertEqual(m0.category, m1.category, msg)
@@ -655,7 +655,7 @@ class TestPmxExporter(unittest.TestCase):
             "DISPLAY": True,  # Check display frames
         }
 
-        print("\n    Check: %s" % str(check_types.keys()))
+        print(f"\n    Check: {str(check_types.keys())}")
 
         for test_num, filepath in enumerate(input_files):
             print("\n     - %2d/%d | filepath: %s" % (test_num + 1, len(input_files), filepath))
@@ -667,7 +667,7 @@ class TestPmxExporter(unittest.TestCase):
                     file_loader = import_pmd_to_pmx
                 source_model = file_loader(filepath)
             except Exception as e:
-                self.fail("Exception happened during loading %s: %s" % (filepath, str(e)))
+                self.fail(f"Exception happened during loading {filepath}: {str(e)}")
 
             # Enable MMD tools and export to temporary file
             try:
@@ -677,16 +677,16 @@ class TestPmxExporter(unittest.TestCase):
                 output_pmx = os.path.join(TESTS_DIR, "output", "%d.pmx" % test_num)
                 bpy.ops.mmd_tools.export_pmx(filepath=output_pmx, scale=1.0, copy_textures=False, sort_materials=False, sort_vertices="NONE", vertex_splitting=False, log_level="ERROR")
             except Exception as e:
-                self.fail("Exception happened during export %s: %s" % (output_pmx, str(e)))
+                self.fail(f"Exception happened during export {output_pmx}: {str(e)}")
 
             # Verify the file was created
-            self.assertTrue(os.path.isfile(output_pmx), "File was not created: %s" % output_pmx)
+            self.assertTrue(os.path.isfile(output_pmx), f"File was not created: {output_pmx}")
 
             # Load the exported PMX file and compare with source
             try:
                 result_model = pmx.load(output_pmx)
             except Exception as e:
-                self.fail("Failed to load output file %s: %s" % (output_pmx, str(e)))
+                self.fail(f"Failed to load output file {output_pmx}: {str(e)}")
 
             # Run all the comparison tests
             self.__check_pmx_header_info(source_model, result_model, check_types.keys())

--- a/tests/test_pmx_exporter_hard.py
+++ b/tests/test_pmx_exporter_hard.py
@@ -184,7 +184,9 @@ class TestPmxExporter(unittest.TestCase):
                 self.assertGreaterEqual(dot_product, 0.99999, f"Normal angle difference too large: dot_product={dot_product:.6f}")
 
             self.assertLess(self.__vector_error(v0.uv, v1.uv), 1e-6)
-            self.assertEqual(v0.additional_uvs, v1.additional_uvs)
+            for uv0, uv1 in zip(v0.additional_uvs, v1.additional_uvs, strict=False):
+                self.assertLess(self.__tuple_error(uv0, uv1), 1e-6)
+
             self.assertEqual(v0.edge_scale, v1.edge_scale)
             self.assertEqual(v0.weight.type, v1.weight.type)
             self.assertEqual(v0.weight.bones, v1.weight.bones)

--- a/tests/test_pmx_exporter_hard.py
+++ b/tests/test_pmx_exporter_hard.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import math
 import os

--- a/tests/test_pmx_exporter_hard.py
+++ b/tests/test_pmx_exporter_hard.py
@@ -31,11 +31,9 @@ class TestPmxExporter(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
-        # logger.setLevel('DEBUG')
-        # logger.setLevel('INFO')
 
     # ********************************************
     # Utils

--- a/tests/test_pmx_exporter_hard.py
+++ b/tests/test_pmx_exporter_hard.py
@@ -628,9 +628,7 @@ class TestPmxExporter(unittest.TestCase):
         for file_type in file_types:
             file_ext = "." + file_type
             for root, dirs, files in os.walk(os.path.join(SAMPLES_DIR, file_type)):
-                for name in files:
-                    if name.lower().endswith(file_ext):
-                        ret.append(os.path.join(root, name))
+                ret.extend(os.path.join(root, name) for name in files if name.lower().endswith(file_ext))
         return ret
 
     def __enable_mmd_tools(self):

--- a/tests/test_pmx_importer_hard.py
+++ b/tests/test_pmx_importer_hard.py
@@ -381,7 +381,7 @@ class TestPmxImporter(unittest.TestCase):
 
             # Verify that display frames reference existing bones
             mmd_root = root_obj.mmd_root
-            bone_names = set(bone.name for bone in armature.pose.bones)
+            bone_names = {bone.name for bone in armature.pose.bones}
 
             for frame in mmd_root.display_item_frames:
                 for item in frame.data:
@@ -881,7 +881,7 @@ class TestPmxImporter(unittest.TestCase):
                     degenerate_faces = 0
                     for poly in mesh_data.polygons:
                         vertices = [mesh_data.vertices[i].co for i in poly.vertices]
-                        if len(set(tuple(v) for v in vertices)) < 3:
+                        if len({tuple(v) for v in vertices}) < 3:
                             degenerate_faces += 1
 
                     print(f"   - Found {degenerate_faces} potentially degenerate faces")

--- a/tests/test_pmx_importer_hard.py
+++ b/tests/test_pmx_importer_hard.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import gc
 import logging
 import math

--- a/tests/test_pmx_importer_hard.py
+++ b/tests/test_pmx_importer_hard.py
@@ -84,9 +84,7 @@ class TestPmxImporter(unittest.TestCase):
         for file_type in file_types:
             file_ext = "." + file_type
             for root, dirs, files in os.walk(os.path.join(SAMPLES_DIR, file_type)):
-                for name in files:
-                    if name.lower().endswith(file_ext):
-                        ret.append(os.path.join(root, name))
+                ret.extend(os.path.join(root, name) for name in files if name.lower().endswith(file_ext))
         return ret
 
     def _enable_mmd_tools(self):

--- a/tests/test_pmx_importer_hard.py
+++ b/tests/test_pmx_importer_hard.py
@@ -32,7 +32,7 @@ class TestPmxImporter(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
-        """Start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
 

--- a/tests/test_pmx_importer_hard.py
+++ b/tests/test_pmx_importer_hard.py
@@ -9,8 +9,8 @@ import shutil
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core.model import Model
-from bl_ext.user_default.mmd_tools.core.pmx.importer import PMXImporter
+from bl_ext.blender_org.mmd_tools.core.model import Model
+from bl_ext.blender_org.mmd_tools.core.pmx.importer import PMXImporter
 from mathutils import Vector
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -91,9 +91,9 @@ class TestPmxImporter(unittest.TestCase):
         """Make sure mmd_tools addon is enabled"""
         bpy.ops.wm.read_homefile(use_empty=True)
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
-        if not pref.addons.get("bl_ext.user_default.mmd_tools", None):
+        if not pref.addons.get("bl_ext.blender_org.mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
 
     def _import_pmx_model(self, filepath, **kwargs):
         """Import PMX model with given parameters"""

--- a/tests/test_pmx_importer_hard.py
+++ b/tests/test_pmx_importer_hard.py
@@ -104,7 +104,7 @@ class TestPmxImporter(unittest.TestCase):
             "clean_model": False,
             "remove_doubles": False,
             "mark_sharp_edges": True,
-            "fix_IK_links": False,
+            "fix_ik_links": False,
             "apply_bone_fixed_axis": False,
             "rename_LR_bones": False,
             "use_underscore": False,
@@ -491,12 +491,12 @@ class TestPmxImporter(unittest.TestCase):
         # Some models might not have bones that can be renamed
         print(f"   - Found L/R suffixed bones: {has_lr_suffix}")
 
-        # Test fix_IK_links option
+        # Test fix_ik_links option
         bpy.ops.object.select_all(action="SELECT")
         bpy.ops.object.delete()
 
-        root_obj = self._import_pmx_model(filepath, fix_IK_links=True, types={"ARMATURE"})
-        self.assertIsNotNone(root_obj, "Failed to import with fix_IK_links=True")
+        root_obj = self._import_pmx_model(filepath, fix_ik_links=True, types={"ARMATURE"})
+        self.assertIsNotNone(root_obj, "Failed to import with fix_ik_links=True")
 
         print("✓ Bone options test passed")
 

--- a/tests/test_pmx_importer_hard.py
+++ b/tests/test_pmx_importer_hard.py
@@ -792,7 +792,7 @@ class TestPmxImporter(unittest.TestCase):
                 self.assertTrue(vertex_order_vg.lock_weight, "Vertex order group should be locked")
 
             # Count bone vertex groups
-            bone_vgs = [vg for vg in vertex_groups if vg.name not in ["mmd_edge_scale", "mmd_vertex_order"]]
+            bone_vgs = [vg for vg in vertex_groups if vg.name not in {"mmd_edge_scale", "mmd_vertex_order"}]
             print(f"   - Found {len(bone_vgs)} bone vertex groups")
 
         print("✓ Vertex weight distribution test passed")

--- a/tests/test_pmx_importer_time.py
+++ b/tests/test_pmx_importer_time.py
@@ -1,0 +1,106 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
+import os
+import time
+import unittest
+
+import bpy
+from bl_ext.blender_org.mmd_tools.core import pmx
+from bl_ext.blender_org.mmd_tools.core.pmd.importer import import_pmd_to_pmx
+from bl_ext.blender_org.mmd_tools.core.pmx.importer import PMXImporter
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+SAMPLES_DIR = os.path.join(os.path.dirname(TESTS_DIR), "samples")
+
+
+class TestPmxImportTime(unittest.TestCase):
+    def __list_sample_files(self, file_types):
+        """List sample files"""
+        ret = []
+        for file_type in file_types:
+            file_ext = "." + file_type
+            for root, dirs, files in os.walk(os.path.join(SAMPLES_DIR, file_type)):
+                ret.extend(os.path.join(root, name) for name in files if name.lower().endswith(file_ext))
+        return ret
+
+    def __enable_mmd_tools(self):
+        """Enable MMD Tools addon"""
+        bpy.ops.wm.read_homefile(use_empty=True)
+        pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
+        if not pref.addons.get("mmd_tools", None):
+            addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
+
+    def test_pmx_import_time(self):
+        """Test PMX import time performance"""
+        input_files = self.__list_sample_files(("pmd", "pmx"))
+        if len(input_files) < 1:
+            self.fail("Required PMX/PMD sample files!")
+
+        # Set import types
+        import_types = {"MESH", "ARMATURE", "PHYSICS", "MORPHS", "DISPLAY"}
+
+        print("\n=== PMX Import Time Test ===")
+        print("Import types: %s" % str(import_types))
+
+        total_time = 0
+        successful_imports = 0
+
+        for test_num, filepath in enumerate(input_files):
+            filename = os.path.basename(filepath)
+            print(f"\n{test_num + 1:2d}/{len(input_files)} | File: {filename}")
+
+            try:
+                # Reset Blender environment
+                self.__enable_mmd_tools()
+
+                # Select file loader
+                file_loader = pmx.load
+                if filepath.lower().endswith(".pmd"):
+                    file_loader = import_pmd_to_pmx
+
+                # Start timing
+                start_time = time.time()
+
+                # Load model
+                source_model = file_loader(filepath)
+
+                # Execute import
+                PMXImporter().execute(
+                    pmx=source_model,
+                    types=import_types,
+                    scale=1,
+                    clean_model=False,
+                )
+
+                # Update scene
+                bpy.context.scene.frame_set(bpy.context.scene.frame_current)
+
+                # End timing
+                end_time = time.time()
+                import_time = end_time - start_time
+
+                print(f"     Import time: {import_time:.3f} seconds")
+
+                total_time += import_time
+                successful_imports += 1
+
+            except Exception as e:
+                print(f"     Import failed: {str(e)}")
+                continue
+
+        # Output statistics
+        print("\n=== Statistics ===")
+        print(f"Successful imports: {successful_imports}/{len(input_files)} files")
+        if successful_imports > 0:
+            print(f"Total time: {total_time:.3f} seconds")
+            print(f"Average time: {total_time / successful_imports:.3f} seconds")
+            print("Fastest import: Please check individual results above")
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.argv = [__file__] + (sys.argv[sys.argv.index("--") + 1 :] if "--" in sys.argv else [])
+    unittest.main()

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -35,7 +35,7 @@ class TestMMDProperties(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
-        """Start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -9,14 +9,14 @@ import shutil
 import time
 import unittest
 
-import bl_ext.user_default.mmd_tools
+import bl_ext.blender_org.mmd_tools
 import bpy
-from bl_ext.user_default.mmd_tools.core.model import Model
-from bl_ext.user_default.mmd_tools.properties.camera import MMDCamera
+from bl_ext.blender_org.mmd_tools.core.model import Model
+from bl_ext.blender_org.mmd_tools.properties.camera import MMDCamera
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 SAMPLES_DIR = os.path.join(os.path.dirname(TESTS_DIR), "samples")
-MMD_TOOLS_PATH = os.path.dirname(bl_ext.user_default.mmd_tools.__file__)
+MMD_TOOLS_PATH = os.path.dirname(bl_ext.blender_org.mmd_tools.__file__)
 TOON_TEXTURE_PATH = os.path.join(MMD_TOOLS_PATH, "externals", "MikuMikuDance", "toon01.bmp")
 
 
@@ -53,9 +53,9 @@ class TestMMDProperties(unittest.TestCase):
         """Make sure mmd_tools addon is enabled"""
         bpy.ops.wm.read_homefile(use_empty=True)
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
-        if not pref.addons.get("bl_ext.user_default.mmd_tools", None):
+        if not pref.addons.get("bl_ext.blender_org.mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
 
     def _create_test_model(self, name: str = "TestModel") -> Model:
         """Create a basic MMD model for testing"""

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import gc
 import logging
 import math

--- a/tests/test_rigid_body.py
+++ b/tests/test_rigid_body.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import gc
 import logging
 import math

--- a/tests/test_rigid_body.py
+++ b/tests/test_rigid_body.py
@@ -33,7 +33,7 @@ class TestRigidBody(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
-        """Start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
 

--- a/tests/test_rigid_body.py
+++ b/tests/test_rigid_body.py
@@ -9,9 +9,9 @@ import shutil
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core import rigid_body
-from bl_ext.user_default.mmd_tools.core.model import FnModel, Model
-from bl_ext.user_default.mmd_tools.core.rigid_body import FnRigidBody
+from bl_ext.blender_org.mmd_tools.core import rigid_body
+from bl_ext.blender_org.mmd_tools.core.model import FnModel, Model
+from bl_ext.blender_org.mmd_tools.core.rigid_body import FnRigidBody
 from mathutils import Euler, Vector
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -75,9 +75,9 @@ class TestRigidBody(unittest.TestCase):
         """Make sure mmd_tools addon is enabled"""
         bpy.ops.wm.read_homefile(use_empty=True)
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
-        if not pref.addons.get("bl_ext.user_default.mmd_tools", None):
+        if not pref.addons.get("bl_ext.blender_org.mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
 
     def _create_test_model(self, name="TestModel"):
         """Create a basic test MMD model with armature"""

--- a/tests/test_scene_setup.py
+++ b/tests/test_scene_setup.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import os
 import unittest

--- a/tests/test_scene_setup.py
+++ b/tests/test_scene_setup.py
@@ -26,7 +26,7 @@ class TestSceneSetup(unittest.TestCase):
                     os.remove(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
 

--- a/tests/test_scene_setup.py
+++ b/tests/test_scene_setup.py
@@ -6,7 +6,7 @@ import os
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools import auto_scene_setup
+from bl_ext.blender_org.mmd_tools import auto_scene_setup
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 SAMPLES_DIR = os.path.join(os.path.dirname(TESTS_DIR), "samples")
@@ -45,7 +45,7 @@ class TestSceneSetup(unittest.TestCase):
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
 
     def __create_test_actions(self):
         """Create test actions with frame ranges for testing setupFrameRanges"""

--- a/tests/test_sdef_system.py
+++ b/tests/test_sdef_system.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import os
 import shutil

--- a/tests/test_sdef_system.py
+++ b/tests/test_sdef_system.py
@@ -30,11 +30,9 @@ class TestSDEFSystem(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
-        # logger.setLevel('DEBUG')
-        # logger.setLevel('INFO')
 
         # Clear the scene
         bpy.ops.wm.read_homefile(use_empty=True)

--- a/tests/test_sdef_system.py
+++ b/tests/test_sdef_system.py
@@ -8,7 +8,7 @@ import unittest
 
 import bmesh
 import bpy
-from bl_ext.user_default.mmd_tools.core.sdef import FnSDEF, _hash
+from bl_ext.blender_org.mmd_tools.core.sdef import FnSDEF, _hash
 from mathutils import Vector
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -59,7 +59,7 @@ class TestSDEFSystem(unittest.TestCase):
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
 
     def __vector_error(self, vec0, vec1):
         return (Vector(vec0) - Vector(vec1)).length

--- a/tests/test_utility_systems.py
+++ b/tests/test_utility_systems.py
@@ -138,7 +138,7 @@ class TestUtilitySystems(unittest.TestCase):
                     "TestPropGroup": test_prop_group,
                     "NotAClass": "string value",
                     "MockPanel": MockPanel,
-                }
+                },
             },
         )()
 

--- a/tests/test_utility_systems.py
+++ b/tests/test_utility_systems.py
@@ -29,7 +29,7 @@ class TestUtilitySystems(unittest.TestCase):
         cls.__enable_mmd_tools()
 
     def setUp(self):
-        """Clean state for each test"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
         # Start with clean scene

--- a/tests/test_utility_systems.py
+++ b/tests/test_utility_systems.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 import bpy
-from bl_ext.user_default.mmd_tools import auto_load, bpyutils, cycles_converter, handlers
-from bl_ext.user_default.mmd_tools.core.exceptions import MaterialNotFoundError
+from bl_ext.blender_org.mmd_tools import auto_load, bpyutils, cycles_converter, handlers
+from bl_ext.blender_org.mmd_tools.core.exceptions import MaterialNotFoundError
 
 
 class TestUtilitySystems(unittest.TestCase):
@@ -42,7 +42,7 @@ class TestUtilitySystems(unittest.TestCase):
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
 
     # ********************************************
     # Exception Tests
@@ -497,11 +497,11 @@ class TestUtilitySystems(unittest.TestCase):
         # Restore
         handlers.MMDHanders.register()
 
-    @patch("bl_ext.user_default.mmd_tools.core.sdef.FnSDEF")
-    @patch("bl_ext.user_default.mmd_tools.core.material.MigrationFnMaterial")
-    @patch("bl_ext.user_default.mmd_tools.core.morph.MigrationFnMorph")
-    @patch("bl_ext.user_default.mmd_tools.core.camera.MigrationFnCamera")
-    @patch("bl_ext.user_default.mmd_tools.core.model.MigrationFnModel")
+    @patch("bl_ext.blender_org.mmd_tools.core.sdef.FnSDEF")
+    @patch("bl_ext.blender_org.mmd_tools.core.material.MigrationFnMaterial")
+    @patch("bl_ext.blender_org.mmd_tools.core.morph.MigrationFnMorph")
+    @patch("bl_ext.blender_org.mmd_tools.core.camera.MigrationFnCamera")
+    @patch("bl_ext.blender_org.mmd_tools.core.model.MigrationFnModel")
     def test_handlers_load_handler(self, mock_model, mock_camera, mock_morph, mock_material, mock_sdef):
         """Test load handler functionality"""
         # Call load handler
@@ -516,7 +516,7 @@ class TestUtilitySystems(unittest.TestCase):
         mock_model.update_mmd_ik_loop_factor.assert_called_once()
         mock_model.update_mmd_tools_version.assert_called_once()
 
-    @patch("bl_ext.user_default.mmd_tools.core.morph.MigrationFnMorph")
+    @patch("bl_ext.blender_org.mmd_tools.core.morph.MigrationFnMorph")
     def test_handlers_save_pre_handler(self, mock_morph):
         """Test save pre handler functionality"""
         # Call save pre handler

--- a/tests/test_utility_systems.py
+++ b/tests/test_utility_systems.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import tempfile
 import unittest

--- a/tests/test_utils_unit.py
+++ b/tests/test_utils_unit.py
@@ -131,7 +131,7 @@ class TestUtilsUnit(unittest.TestCase):
             ("左足首", "足首.L"),  # Left ankle
             ("右足首", "足首.R"),  # Right ankle
             ("胴体", "胴体"),  # Torso (no conversion needed)
-            ("頭", "頭")       # Head (no conversion needed)
+            ("頭", "頭"),       # Head (no conversion needed)
         ]
 
         # Test with default delimiter (dot)
@@ -153,7 +153,7 @@ class TestUtilsUnit(unittest.TestCase):
             ("腕_L", "左腕"),  # Left arm with underscore
             ("腕_R", "右腕"),  # Right arm with underscore
             ("胴体", "胴体"),  # Torso (no conversion needed)
-            ("頭", "頭")       # Head (no conversion needed)
+            ("頭", "頭"),       # Head (no conversion needed)
         ]
 
         for input_name, expected_output in test_cases:

--- a/tests/test_utils_unit.py
+++ b/tests/test_utils_unit.py
@@ -12,7 +12,7 @@ from bl_ext.blender_org.mmd_tools.utils import ItemOp, clearUnusedMeshes, conver
 class TestUtilsUnit(unittest.TestCase):
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         # Ensure active object exists (user may have deleted the default cube)
         if not bpy.context.active_object:
             bpy.ops.mesh.primitive_cube_add()

--- a/tests/test_utils_unit.py
+++ b/tests/test_utils_unit.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_utils_unit.py
+++ b/tests/test_utils_unit.py
@@ -6,7 +6,7 @@ import unittest
 from unittest.mock import patch
 
 import bpy
-from bl_ext.user_default.mmd_tools.utils import ItemOp, clearUnusedMeshes, convertLRToName, convertNameToLR, deprecated, enterEditMode, int2base, makePmxBoneMap, mergeVertexGroup, saferelpath, selectAObject, selectSingleBone, separateByMaterials, setParentToBone, unique_name
+from bl_ext.blender_org.mmd_tools.utils import ItemOp, clearUnusedMeshes, convertLRToName, convertNameToLR, deprecated, enterEditMode, int2base, makePmxBoneMap, mergeVertexGroup, saferelpath, selectAObject, selectSingleBone, separateByMaterials, setParentToBone, unique_name
 
 
 class TestUtilsUnit(unittest.TestCase):

--- a/tests/test_vertex_color.py
+++ b/tests/test_vertex_color.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import os
 import shutil

--- a/tests/test_vertex_color.py
+++ b/tests/test_vertex_color.py
@@ -8,7 +8,7 @@ import unittest
 
 import bmesh
 import bpy
-from bl_ext.user_default.mmd_tools.core import pmx
+from bl_ext.blender_org.mmd_tools.core import pmx
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 SAMPLES_DIR = os.path.join(os.path.dirname(TESTS_DIR), "samples")
@@ -57,7 +57,7 @@ class TestVertexColorExporter(unittest.TestCase):
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")  # make sure addon 'mmd_tools' is enabled
+            addon_enable(module="bl_ext.blender_org.mmd_tools")  # make sure addon 'mmd_tools' is enabled
 
     def __create_mmd_model(self, name):
         """

--- a/tests/test_vertex_color.py
+++ b/tests/test_vertex_color.py
@@ -293,6 +293,7 @@ class TestVertexColorExporter(unittest.TestCase):
                 sort_materials=False,
                 sort_vertices="NONE",
                 vertex_splitting=False,
+                export_vertex_colors_as_adduv2=True,
                 log_level="WARNING",  # Reduce log noise for cleaner test output
             )
         except Exception as e:

--- a/tests/test_vertex_color.py
+++ b/tests/test_vertex_color.py
@@ -31,7 +31,7 @@ class TestVertexColorExporter(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
         # Clear the scene

--- a/tests/test_vertex_color.py
+++ b/tests/test_vertex_color.py
@@ -353,9 +353,7 @@ class TestVertexColorExporter(unittest.TestCase):
 
         # Check for precision vs mapping errors
         expected_color_set = set()
-        for expected_color in expected_mapping.values():
-            # Convert to tuple for set operations
-            expected_color_set.add(tuple(expected_color))
+        expected_color_set.update(tuple(expected_color) for expected_color in expected_mapping.values())
 
         for vertex_idx, exported_color in exported_vertex_colors:
             # Find closest expected color
@@ -777,8 +775,7 @@ class TestVertexColorExporter(unittest.TestCase):
                 exported_colors.append(color_tuple)
 
         original_colors = set()
-        for color in original_loop_colors.values():
-            original_colors.add(tuple(round(c, 3) for c in color))
+        original_colors.update(tuple(round(c, 3) for c in color) for color in original_loop_colors.values())
 
         exported_color_set = set(exported_colors)
 

--- a/tests/test_vmd_exporter.py
+++ b/tests/test_vmd_exporter.py
@@ -67,9 +67,7 @@ class TestVmdExporter(unittest.TestCase):
         for file_type in file_types:
             file_ext = "." + file_type
             for root, dirs, files in os.walk(os.path.join(SAMPLES_DIR, file_type)):
-                for name in files:
-                    if name.lower().endswith(file_ext):
-                        ret.append(os.path.join(root, name))
+                ret.extend(os.path.join(root, name) for name in files if name.lower().endswith(file_ext))
         return ret
 
     def __enable_mmd_tools(self):

--- a/tests/test_vmd_exporter.py
+++ b/tests/test_vmd_exporter.py
@@ -235,16 +235,16 @@ class TestVmdExporter(unittest.TestCase):
                 # x2, y2 parameters allow == 107
                 is_valid = s == r  # Always allow source == result
 
-                if param_type in ["x1", "y1"]:
+                if param_type in {"x1", "y1"}:
                     is_valid = is_valid or (r == 20)
-                elif param_type in ["x2", "y2"]:
+                elif param_type in {"x2", "y2"}:
                     is_valid = is_valid or (r == 107)
 
                 if not is_valid:
                     expected_values = ["same as source"]
-                    if param_type in ["x1", "y1"]:
+                    if param_type in {"x1", "y1"}:
                         expected_values.append("20")
-                    elif param_type in ["x2", "y2"]:
+                    elif param_type in {"x2", "y2"}:
                         expected_values.append("107")
 
                     error_count += 1
@@ -255,17 +255,17 @@ class TestVmdExporter(unittest.TestCase):
                 # For linear interpolation, allow result to be 20, 107 for corresponding positions
                 is_valid = s == r  # Always allow source == result
 
-                if param_type in ["x1", "y1"]:
+                if param_type in {"x1", "y1"}:
                     is_valid = is_valid or (r == 20)
-                elif param_type in ["x2", "y2"]:
+                elif param_type in {"x2", "y2"}:
                     is_valid = is_valid or (r == 107)
 
                 if not is_valid:
                     error_count += 1
                     expected_values = ["same as source"]
-                    if param_type in ["x1", "y1"]:
+                    if param_type in {"x1", "y1"}:
                         expected_values.append("20")
-                    elif param_type in ["x2", "y2"]:
+                    elif param_type in {"x2", "y2"}:
                         expected_values.append("107")
                     print(f"        Invalid for linear interp at index {j:2d} ({param_name:>4}): {s:4d} -> {r:4d} (expected: {' or '.join(expected_values)}), {msg}")
                     max_error = max(max_error, abs(s - r))

--- a/tests/test_vmd_exporter.py
+++ b/tests/test_vmd_exporter.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import math
 import os

--- a/tests/test_vmd_exporter.py
+++ b/tests/test_vmd_exporter.py
@@ -32,7 +32,7 @@ class TestVmdExporter(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
 

--- a/tests/test_vmd_exporter.py
+++ b/tests/test_vmd_exporter.py
@@ -462,7 +462,7 @@ class TestVmdExporter(unittest.TestCase):
                     mesh_obj.select_set(True)
 
                 # Import VMD motion
-                bpy.ops.mmd_tools.import_vmd(files=[{"name": os.path.basename(vmd_file)}], directory=os.path.dirname(vmd_file), scale=0.08, margin=0, bone_mapper="PMX", use_pose_mode=False, use_mirror=False, update_scene_settings=True, always_create_new_action=True, use_NLA=False)
+                bpy.ops.mmd_tools.import_vmd(files=[{"name": os.path.basename(vmd_file)}], directory=os.path.dirname(vmd_file), scale=0.08, margin=0, bone_mapper="PMX", use_pose_mode=False, use_mirror=False, update_scene_settings=True, always_create_new_action=True, use_nla=False)
                 print("    VMD imported successfully")
 
                 # Export VMD motion

--- a/tests/test_vmd_exporter.py
+++ b/tests/test_vmd_exporter.py
@@ -9,8 +9,8 @@ import traceback
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core import vmd
-from bl_ext.user_default.mmd_tools.core.model import Model
+from bl_ext.blender_org.mmd_tools.core import vmd
+from bl_ext.blender_org.mmd_tools.core.model import Model
 from mathutils import Quaternion, Vector
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -75,7 +75,7 @@ class TestVmdExporter(unittest.TestCase):
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
         if not pref.addons.get("mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")  # make sure addon 'mmd_tools' is enabled
+            addon_enable(module="bl_ext.blender_org.mmd_tools")  # make sure addon 'mmd_tools' is enabled
 
     def __get_largest_pmx_file(self):
         """Get the largest PMX file from samples"""

--- a/tests/test_vmd_importer.py
+++ b/tests/test_vmd_importer.py
@@ -30,7 +30,7 @@ class TestVMDImporter(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
-        """Start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
 

--- a/tests/test_vmd_importer.py
+++ b/tests/test_vmd_importer.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import os
 import shutil

--- a/tests/test_vmd_importer.py
+++ b/tests/test_vmd_importer.py
@@ -437,7 +437,7 @@ class TestVMDImporter(unittest.TestCase):
 
                 # Show bone matching info
                 if vmd_analysis["bone_animation"]:
-                    target_bones = set(bone.name for bone in target_obj.pose.bones)
+                    target_bones = {bone.name for bone in target_obj.pose.bones}
                     vmd_bones = set(vmd_analysis["bone_animation"].keys())
                     matching_bones = target_bones & vmd_bones
                     print(f"Matching bones: {len(matching_bones)} out of {len(vmd_bones)} VMD bones")
@@ -453,7 +453,7 @@ class TestVMDImporter(unittest.TestCase):
 
                     # Show shape key matching info
                     if vmd_analysis["shape_key_animation"]:
-                        target_shapes = set(key.name for key in target_obj.data.shape_keys.key_blocks if key.name != "Basis")
+                        target_shapes = {key.name for key in target_obj.data.shape_keys.key_blocks if key.name != "Basis"}
                         vmd_shapes = set(vmd_analysis["shape_key_animation"].keys())
                         matching_shapes = target_shapes & vmd_shapes
                         print(f"Matching shape keys: {matching_shapes}")

--- a/tests/test_vmd_importer.py
+++ b/tests/test_vmd_importer.py
@@ -502,7 +502,7 @@ class TestVMDImporter(unittest.TestCase):
         self.assertFalse(importer._VMDImporter__bone_util_cls == BoneConverterPoseMode)
         self.assertTrue(importer._VMDImporter__convert_mmd_camera)
         self.assertTrue(importer._VMDImporter__convert_mmd_lamp)
-        expected_margin = 5 if importer._VMDImporter__frame_start == 1 else 0
+        expected_margin = 5 if importer._VMDImporter__frame_start in {0, 1} else 0
         self.assertEqual(importer._VMDImporter__frame_margin, expected_margin)
         self.assertFalse(importer._VMDImporter__mirror)
 
@@ -512,7 +512,7 @@ class TestVMDImporter(unittest.TestCase):
         self.assertTrue(importer._VMDImporter__bone_util_cls == BoneConverterPoseMode)
         self.assertFalse(importer._VMDImporter__convert_mmd_camera)
         self.assertFalse(importer._VMDImporter__convert_mmd_lamp)
-        expected_custom_margin = 10 if importer._VMDImporter__frame_start == 1 else 0
+        expected_custom_margin = 10 if importer._VMDImporter__frame_start in {0, 1} else 0
         self.assertEqual(importer._VMDImporter__frame_margin, expected_custom_margin)
         self.assertTrue(importer._VMDImporter__mirror)
 

--- a/tests/test_vmd_importer.py
+++ b/tests/test_vmd_importer.py
@@ -54,9 +54,7 @@ class TestVMDImporter(unittest.TestCase):
 
         ret = []
         for root, dirs, files in os.walk(directory):
-            for name in files:
-                if name.lower().endswith("." + extension.lower()):
-                    ret.append(os.path.join(root, name))
+            ret.extend(os.path.join(root, name) for name in files if name.lower().endswith("." + extension.lower()))
         return ret
 
     def _enable_mmd_tools(self):

--- a/tests/test_vmd_importer.py
+++ b/tests/test_vmd_importer.py
@@ -969,15 +969,15 @@ class TestVMDImporter(unittest.TestCase):
         except AssertionError:
             self.fail("Plugin has assertion issues with custom bone mappers - this is a plugin bug")
 
-    def test_vmd_import_use_NLA(self):
-        """Test VMD importing with use_NLA option"""
+    def test_vmd_import_use_nla(self):
+        """Test VMD importing with use_nla option"""
         vmd_files = self._list_sample_files("vmd", "vmd")
         if not vmd_files:
             self.fail("No VMD sample files found for NLA test")
 
         armature = self._create_standard_mmd_armature()
 
-        importer = VMDImporter(filepath=vmd_files[0], use_NLA=True)
+        importer = VMDImporter(filepath=vmd_files[0], use_nla=True)
         importer.assign(armature)
 
         self.assertIsNotNone(armature.animation_data, "Animation data should be created")

--- a/tests/test_vmd_importer.py
+++ b/tests/test_vmd_importer.py
@@ -7,8 +7,8 @@ import shutil
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core.model import Model
-from bl_ext.user_default.mmd_tools.core.vmd.importer import BoneConverter, BoneConverterPoseMode, RenamedBoneMapper, VMDImporter, _FnBezier, _MirrorMapper
+from bl_ext.blender_org.mmd_tools.core.model import Model
+from bl_ext.blender_org.mmd_tools.core.vmd.importer import BoneConverter, BoneConverterPoseMode, RenamedBoneMapper, VMDImporter, _FnBezier, _MirrorMapper
 from mathutils import Quaternion, Vector
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -61,9 +61,9 @@ class TestVMDImporter(unittest.TestCase):
         """Make sure mmd_tools addon is enabled"""
         bpy.ops.wm.read_homefile(use_empty=True)
         pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
-        if not pref.addons.get("bl_ext.user_default.mmd_tools", None):
+        if not pref.addons.get("bl_ext.blender_org.mmd_tools", None):
             addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
-            addon_enable(module="bl_ext.user_default.mmd_tools")
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
 
     def _create_standard_mmd_armature(self):
         """Create armature with standard MMD bone names"""

--- a/tests/test_vmd_importer_time.py
+++ b/tests/test_vmd_importer_time.py
@@ -1,0 +1,340 @@
+# Copyright 2025 MMD Tools authors
+# Simplified VMD import time test script (including mesh tests) - unittest version
+
+import os
+import time
+import unittest
+
+import bpy
+from bl_ext.blender_org.mmd_tools.core.vmd.importer import VMDImporter
+
+# Test file path configuration
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+SAMPLES_DIR = os.path.join(os.path.dirname(TESTS_DIR), "samples")
+
+
+class TestVmdImportTime(unittest.TestCase):
+    def setUp(self):
+        """Set up testing environment"""
+        self.enable_mmd_tools()
+
+    def list_sample_files(self, dir_name, extension):
+        """List all files with specified extension in the specified directory"""
+        directory = os.path.join(SAMPLES_DIR, dir_name)
+        if not os.path.exists(directory):
+            return []
+
+        ret = []
+        for root, dirs, files in os.walk(directory):
+            ret.extend(os.path.join(root, name) for name in files if name.lower().endswith("." + extension.lower()))
+        return ret
+
+    def clear_scene(self):
+        """Clear scene"""
+        bpy.ops.object.select_all(action="SELECT")
+        bpy.ops.object.delete(use_global=True)
+
+    def enable_mmd_tools(self):
+        """Enable mmd_tools addon"""
+        bpy.ops.wm.read_homefile(use_empty=True)
+        pref = getattr(bpy.context, "preferences", None) or bpy.context.user_preferences
+        if not pref.addons.get("bl_ext.blender_org.mmd_tools", None):
+            addon_enable = bpy.ops.wm.addon_enable if "addon_enable" in dir(bpy.ops.wm) else bpy.ops.preferences.addon_enable
+            addon_enable(module="bl_ext.blender_org.mmd_tools")
+
+    def import_pmx_model(self, pmx_file):
+        """Import PMX model"""
+        self.clear_scene()
+
+        bpy.ops.mmd_tools.import_model(filepath=pmx_file, scale=1.0, types={"MESH", "ARMATURE", "MORPHS"}, clean_model=False, log_level="ERROR")
+
+        # Find imported model root object
+        for obj in bpy.context.scene.objects:
+            if obj.mmd_type == "ROOT":
+                return obj
+        return None
+
+    def find_model_components(self, model_root):
+        """Find model components"""
+        components = {"armature": None, "meshes": []}
+
+        # Iterate through all objects to find armature and meshes
+        for obj in bpy.context.scene.objects:
+            if obj.type == "ARMATURE":
+                # Check if it belongs to this model
+                if model_root in {obj.parent, obj} or (hasattr(obj, "mmd_type") and obj.mmd_type != "NONE"):
+                    components["armature"] = obj
+
+            elif obj.type == "MESH":
+                # Check if it belongs to this model and has shape keys
+                if (obj.parent and obj.parent.parent == model_root) or obj.parent == model_root:
+                    components["meshes"].append(obj)
+
+        return components
+
+    def clean_animation_data(self, obj, obj_type):
+        """Clean animation data from object"""
+        if obj_type == "mesh" and obj.data.shape_keys and obj.data.shape_keys.animation_data:
+            if obj.data.shape_keys.animation_data.action:
+                bpy.data.actions.remove(obj.data.shape_keys.animation_data.action)
+        elif obj.animation_data and obj.animation_data.action:
+            bpy.data.actions.remove(obj.animation_data.action)
+
+    def count_fcurves(self, obj, obj_type):
+        """Count animation fcurves of object"""
+        if obj_type == "mesh" and obj.data.shape_keys and obj.data.shape_keys.animation_data:
+            action = obj.data.shape_keys.animation_data.action
+            return len(action.fcurves) if action else 0
+        if obj.animation_data and obj.animation_data.action:
+            return len(obj.animation_data.action.fcurves)
+        return 0
+
+    def assign_vmd_to_object(self, importer, target_obj, obj_type, obj_name):
+        """Use the existing VMD importer to assign to specified object"""
+        # Clean previous animation data
+        self.clean_animation_data(target_obj, obj_type)
+
+        # Start timing assign operation
+        start_time = time.time()
+
+        # Use existing importer to execute assign
+        importer.assign(target_obj)
+
+        assign_time = time.time() - start_time
+
+        # Check number of created animation fcurves
+        fcurves_count = self.count_fcurves(target_obj, obj_type)
+
+        return {"success": True, "time": assign_time, "fcurves": fcurves_count}
+
+    def test_vmd_import_performance(self):
+        """Test VMD import performance"""
+        print("=== VMD Import Time Test ===")
+
+        # Get test files
+        pmx_files = self.list_sample_files("pmx", "pmx")
+        pmx_files.extend(self.list_sample_files("pmd", "pmd"))
+        vmd_files = self.list_sample_files("vmd", "vmd")
+
+        # Check test conditions
+        self.assertGreater(len(pmx_files), 0, "No PMX/PMD model files found")
+        self.assertGreater(len(vmd_files), 0, "No VMD animation files found")
+
+        print(f"Found {len(pmx_files)} model files")
+        print(f"Found {len(vmd_files)} VMD files")
+
+        # Import PMX model
+        pmx_file = pmx_files[0]
+        model_name = os.path.splitext(os.path.basename(pmx_file))[0]
+        print(f"\nImporting model: {model_name}")
+
+        model_start_time = time.time()
+        model_root = self.import_pmx_model(pmx_file)
+        model_import_time = time.time() - model_start_time
+
+        self.assertIsNotNone(model_root, "Model import failed")
+        print(f"✓ Model import completed, time: {model_import_time:.2f} seconds")
+
+        # Find model components
+        components = self.find_model_components(model_root)
+        armature = components["armature"]
+        meshes = components["meshes"]
+
+        self.assertIsNotNone(armature, "Armature object not found")
+        print(f"✓ Found armature object, contains {len(armature.pose.bones)} bones")
+        print(f"✓ Found {len(meshes)} mesh objects")
+
+        # Display meshes with shape keys
+        shape_key_meshes = []
+        for mesh in meshes:
+            if mesh.data.shape_keys and len(mesh.data.shape_keys.key_blocks) > 1:
+                shape_key_count = len(mesh.data.shape_keys.key_blocks) - 1  # Subtract Basis
+                shape_key_meshes.append((mesh, shape_key_count))
+                print(f"  - {mesh.name}: {shape_key_count} shape keys")
+
+        if not shape_key_meshes:
+            print("  ⚠ No mesh objects with shape keys found")
+
+        # Test import time for each VMD file
+        print(f"\nStarting test for {len(vmd_files)} VMD files import time:")
+        print("=" * 80)
+
+        all_results = []
+        successful_tests = 0
+        total_tests = 0
+
+        for i, vmd_file in enumerate(vmd_files, 1):
+            vmd_name = os.path.splitext(os.path.basename(vmd_file))[0]
+            print(f"\n[{i}/{len(vmd_files)}] Testing VMD: {vmd_name}")
+            print("-" * 60)
+
+            vmd_results = {"vmd_name": vmd_name, "load_time": 0, "armature": None, "meshes": []}
+
+            # Read VMD file
+            print("Reading VMD file...")
+            load_start_time = time.time()
+            try:
+                importer = VMDImporter(filepath=vmd_file)
+                load_time = time.time() - load_start_time
+                vmd_results["load_time"] = load_time
+                print(f"✓ VMD file read completed, time: {load_time:.3f} seconds")
+            except Exception as e:
+                print(f"✗ VMD file read failed: {e}")
+                continue
+
+            # Test armature import
+            print("Testing armature animation assign...")
+            try:
+                armature_result = self.assign_vmd_to_object(importer, armature, "armature", armature.name)
+                vmd_results["armature"] = armature_result
+                total_tests += 1
+
+                if armature_result["success"]:
+                    print(f"  ✓ Armature assign completed, time: {armature_result['time']:.3f} seconds, created {armature_result['fcurves']} animation fcurves")
+                    successful_tests += 1
+                else:
+                    print(f"  ✗ Armature assign failed: {armature_result.get('error', 'Unknown error')}")
+            except Exception as e:
+                print(f"  ✗ Armature assign failed: {e}")
+                vmd_results["armature"] = {"success": False, "error": str(e), "time": 0, "fcurves": 0}
+                total_tests += 1
+
+            # Test each mesh with shape keys import
+            if shape_key_meshes:
+                print("Testing shape key animation assign...")
+                for mesh, shape_count in shape_key_meshes:
+                    print(f"  Testing mesh: {mesh.name} ({shape_count} shape keys)")
+                    try:
+                        mesh_result = self.assign_vmd_to_object(importer, mesh, "mesh", mesh.name)
+                        mesh_result["mesh_name"] = mesh.name
+                        mesh_result["shape_count"] = shape_count
+                        vmd_results["meshes"].append(mesh_result)
+                        total_tests += 1
+
+                        if mesh_result["success"]:
+                            print(f"    ✓ Mesh assign completed, time: {mesh_result['time']:.3f} seconds, created {mesh_result['fcurves']} animation fcurves")
+                            successful_tests += 1
+                        else:
+                            print(f"    ✗ Mesh assign failed: {mesh_result.get('error', 'Unknown error')}")
+                    except Exception as e:
+                        print(f"    ✗ Mesh assign failed: {e}")
+                        mesh_result = {"success": False, "error": str(e), "time": 0, "fcurves": 0, "mesh_name": mesh.name, "shape_count": shape_count}
+                        vmd_results["meshes"].append(mesh_result)
+                        total_tests += 1
+            else:
+                print("  ⚠ Skipping shape key test (no available shape key meshes)")
+
+            all_results.append(vmd_results)
+
+        # Output summary report
+        self.print_summary_report(all_results)
+
+        # Calculate success rate
+        success_rate = successful_tests / total_tests if total_tests > 0 else 0
+        print(f"\nTest success rate: {success_rate:.1%} ({successful_tests}/{total_tests})")
+
+        # Assert all tests passed
+        self.assertEqual(successful_tests, total_tests, "Some tests failed")
+
+    def print_summary_report(self, all_results):
+        """Print summary report"""
+        print("\n" + "=" * 80)
+        print("VMD Import Time Test Results Summary (Optimized Version)")
+        print("=" * 80)
+
+        # VMD loading time statistics
+        load_results = [r for r in all_results if r["load_time"] > 0]
+        if load_results:
+            print("\nVMD File Loading Time Statistics")
+            print("-" * 50)
+            for result in load_results:
+                print(f"{result['vmd_name']:<30} {result['load_time']:>8.3f} seconds")
+
+            load_times = [r["load_time"] for r in load_results]
+            print("-" * 50)
+            print(f"Average loading time: {sum(load_times) / len(load_times):.3f} seconds")
+            print(f"Fastest loading time: {min(load_times):.3f} seconds")
+            print(f"Slowest loading time: {max(load_times):.3f} seconds")
+
+        # Armature animation statistics
+        armature_results = [r["armature"] for r in all_results if r["armature"] and r["armature"]["success"]]
+        if armature_results:
+            print(f"\nArmature Animation Assign Results (Success: {len(armature_results)}/{len(all_results)})")
+            print("-" * 50)
+
+            for result in all_results:
+                vmd_name = result["vmd_name"]
+                arm_result = result["armature"]
+                if arm_result and arm_result["success"]:
+                    print(f"{vmd_name:<30} {arm_result['time']:>8.3f}s {arm_result['fcurves']:>6} fcurves")
+                else:
+                    print(f"{vmd_name:<30} {'Failed':>15}")
+
+            # Armature statistics
+            arm_times = [r["time"] for r in armature_results]
+            arm_fcurves = [r["fcurves"] for r in armature_results]
+            print("-" * 50)
+            print(f"Average armature assign time: {sum(arm_times) / len(arm_times):.3f} seconds")
+            print(f"Fastest armature assign time: {min(arm_times):.3f} seconds")
+            print(f"Slowest armature assign time: {max(arm_times):.3f} seconds")
+            print(f"Average animation fcurves: {sum(arm_fcurves) / len(arm_fcurves):.1f}")
+
+        # Shape key animation statistics
+        all_mesh_results = []
+        for result in all_results:
+            all_mesh_results.extend([m for m in result["meshes"] if m["success"]])
+
+        if all_mesh_results:
+            print(f"\nShape Key Animation Assign Results (Success: {len(all_mesh_results)} tests)")
+            print("-" * 50)
+
+            for result in all_results:
+                vmd_name = result["vmd_name"]
+                if result["meshes"]:
+                    for mesh_result in result["meshes"]:
+                        if mesh_result["success"]:
+                            print(f"{vmd_name:<20} {mesh_result['mesh_name']:<15} {mesh_result['time']:>8.3f}s {mesh_result['fcurves']:>6} fcurves")
+                        else:
+                            print(f"{vmd_name:<20} {mesh_result['mesh_name']:<15} {'Failed':>15}")
+
+            # Shape key statistics
+            mesh_times = [r["time"] for r in all_mesh_results]
+            mesh_fcurves = [r["fcurves"] for r in all_mesh_results]
+            print("-" * 50)
+            print(f"Average shape key assign time: {sum(mesh_times) / len(mesh_times):.3f} seconds")
+            print(f"Fastest shape key assign time: {min(mesh_times):.3f} seconds")
+            print(f"Slowest shape key assign time: {max(mesh_times):.3f} seconds")
+            print(f"Average animation fcurves: {sum(mesh_fcurves) / len(mesh_fcurves):.1f}")
+        else:
+            print("\n⚠ No successful shape key animation assign tests")
+
+        # Overall statistics
+        total_successful = len(armature_results) + len(all_mesh_results)
+        total_tests = len([r for r in all_results if r["armature"]]) + sum(len(r["meshes"]) for r in all_results)
+
+        print("\nOverall Statistics:")
+        print(f"Total tests: {total_tests}")
+        print(f"Successful tests: {total_successful}")
+        if total_tests > 0:
+            print(f"Success rate: {total_successful / total_tests * 100:.1f}%")
+
+        # Performance improvement summary
+        if load_results and (armature_results or all_mesh_results):
+            print("\nPerformance Improvement Summary:")
+            avg_load_time = sum(r["load_time"] for r in load_results) / len(load_results)
+
+            if armature_results:
+                avg_arm_assign = sum(r["time"] for r in armature_results) / len(armature_results)
+                print(f"Average VMD loading time: {avg_load_time:.3f} seconds")
+                print(f"Average armature assign time: {avg_arm_assign:.3f} seconds")
+
+            if all_mesh_results:
+                avg_mesh_assign = sum(r["time"] for r in all_mesh_results) / len(all_mesh_results)
+                print(f"Average shape key assign time: {avg_mesh_assign:.3f} seconds")
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.argv = [__file__] + (sys.argv[sys.argv.index("--") + 1 :] if "--" in sys.argv else [])
+    unittest.main()

--- a/tests/test_vpd_exporter.py
+++ b/tests/test_vpd_exporter.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import os
 import shutil

--- a/tests/test_vpd_exporter.py
+++ b/tests/test_vpd_exporter.py
@@ -55,9 +55,7 @@ class TestVPDExporter(unittest.TestCase):
 
         ret = []
         for root, dirs, files in os.walk(directory):
-            for name in files:
-                if name.lower().endswith("." + extension.lower()):
-                    ret.append(os.path.join(root, name))
+            ret.extend(os.path.join(root, name) for name in files if name.lower().endswith("." + extension.lower()))
         return ret
 
     def __enable_mmd_tools(self):

--- a/tests/test_vpd_exporter.py
+++ b/tests/test_vpd_exporter.py
@@ -160,7 +160,7 @@ class TestVPDExporter(unittest.TestCase):
             for j, bone in enumerate(armature.pose.bones):
                 if j % (i + 1) == 0:  # Create different patterns for different poses
                     bone.location = Vector((0.1 * i, 0.2 * i, 0.3 * i))
-                    bone.rotation_quaternion = Quaternion(((0.9, 0.1 * i, 0.2 * i, 0.3 * i)))
+                    bone.rotation_quaternion = Quaternion((0.9, 0.1 * i, 0.2 * i, 0.3 * i))
                     bone.keyframe_insert(data_path="location", frame=i + 1)
                     bone.keyframe_insert(data_path="rotation_quaternion", frame=i + 1)
 

--- a/tests/test_vpd_exporter.py
+++ b/tests/test_vpd_exporter.py
@@ -32,7 +32,7 @@ class TestVPDExporter(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
 

--- a/tests/test_vpd_exporter.py
+++ b/tests/test_vpd_exporter.py
@@ -439,7 +439,7 @@ class TestVPDExporter(unittest.TestCase):
                     exporter = VPDExporter()
 
                     # For ACTIVE and ALL pose types, we need animation data
-                    if pose_type in ["ACTIVE", "ALL"]:
+                    if pose_type in {"ACTIVE", "ALL"}:
                         # Ensure armature has animation data
                         if armature.animation_data is None:
                             armature.animation_data_create()
@@ -526,7 +526,7 @@ class TestVPDExporter(unittest.TestCase):
 
                 except Exception as e:
                     # For older Blender versions, pose_library might not be available
-                    if "pose_library" in str(e) and pose_type in ["ACTIVE", "ALL"]:
+                    if "pose_library" in str(e) and pose_type in {"ACTIVE", "ALL"}:
                         print(f"!! Skipped pose_type={pose_type}, use_pose_mode={use_pose_mode}: {str(e)}")
                         print("   This is normal if your Blender version doesn't support pose libraries")
                     else:

--- a/tests/test_vpd_exporter.py
+++ b/tests/test_vpd_exporter.py
@@ -397,9 +397,9 @@ class TestVPDExporter(unittest.TestCase):
             self.assertTrue(os.path.exists(output_path_2x), "Scale 2x VPD file was not created")
 
             # Read both files to compare content
-            with open(output_path_1x, "r", encoding="utf-8", errors="replace") as f1:
+            with open(output_path_1x, encoding="utf-8", errors="replace") as f1:
                 content_1x = f1.read()
-            with open(output_path_2x, "r", encoding="utf-8", errors="replace") as f2:
+            with open(output_path_2x, encoding="utf-8", errors="replace") as f2:
                 content_2x = f2.read()
 
             # Files should be different due to scale difference
@@ -493,7 +493,7 @@ class TestVPDExporter(unittest.TestCase):
                                        f"VPD file empty for {pose_type}, use_pose_mode={use_pose_mode}")
 
                         # Check content (without assuming Japanese characters work correctly)
-                        with open(output_path, "r", encoding="cp932", errors="replace") as f:
+                        with open(output_path, encoding="cp932", errors="replace") as f:
                             content = f.read()
                             # Check for markers that should be present in any VPD file
                             self.assertIn("Vocaloid Pose Data file", content,
@@ -601,7 +601,7 @@ class TestVPDExporter(unittest.TestCase):
             self.assertTrue(os.path.getsize(output_path) > 0, "VPD file for real model is empty")
 
             # Simple verification by checking file content
-            with open(output_path, "r", encoding="cp932", errors="replace") as f:
+            with open(output_path, encoding="cp932", errors="replace") as f:
                 content = f.read()
                 # The file should contain the model name in OSM format
                 self.assertIn(f"{model_name}.osm", content, "Model name not found in VPD file")

--- a/tests/test_vpd_exporter.py
+++ b/tests/test_vpd_exporter.py
@@ -71,7 +71,7 @@ class TestVPDExporter(unittest.TestCase):
                 else bpy.ops.preferences.addon_enable
             )
             addon_enable(
-                module="bl_ext.user_default.mmd_tools"
+                module="bl_ext.user_default.mmd_tools",
             )  # make sure addon 'mmd_tools' is enabled
 
     def __create_model_from_pmx(self, pmx_file):
@@ -281,7 +281,7 @@ class TestVPDExporter(unittest.TestCase):
                 filepath=output_path,
                 scale=1.0,
                 model_name="TestModel",
-                pose_type="CURRENT"
+                pose_type="CURRENT",
             )
 
             # Verify file was created
@@ -330,7 +330,7 @@ class TestVPDExporter(unittest.TestCase):
                 filepath=active_pose_path,
                 scale=1.0,
                 model_name="TestModel",
-                pose_type="ACTIVE"
+                pose_type="ACTIVE",
             )
 
             # Verify active pose file was created
@@ -344,7 +344,7 @@ class TestVPDExporter(unittest.TestCase):
                 filepath=all_poses_path,
                 scale=1.0,
                 model_name="TestModel",
-                pose_type="ALL"
+                pose_type="ALL",
             )
 
             # Verify all pose files were created
@@ -379,7 +379,7 @@ class TestVPDExporter(unittest.TestCase):
                 filepath=output_path_1x,
                 scale=1.0,
                 model_name="TestModel",
-                pose_type="CURRENT"
+                pose_type="CURRENT",
             )
 
             # Export with scale 2.0
@@ -389,7 +389,7 @@ class TestVPDExporter(unittest.TestCase):
                 filepath=output_path_2x,
                 scale=2.0,
                 model_name="TestModel",
-                pose_type="CURRENT"
+                pose_type="CURRENT",
             )
 
             # Verify both files were created
@@ -482,7 +482,7 @@ class TestVPDExporter(unittest.TestCase):
                         scale=1.0,
                         model_name="TestModel",
                         pose_type=pose_type,
-                        use_pose_mode=use_pose_mode
+                        use_pose_mode=use_pose_mode,
                     )
 
                     # Check output for CURRENT pose type
@@ -593,7 +593,7 @@ class TestVPDExporter(unittest.TestCase):
                 filepath=output_path,
                 scale=1.0,
                 model_name=model_name,
-                pose_type="CURRENT"
+                pose_type="CURRENT",
             )
 
             # Verify export succeeded
@@ -629,7 +629,7 @@ class TestVPDExporter(unittest.TestCase):
                 filepath=output_path,
                 scale=1.0,
                 model_name="TestDirectAPI",
-                pose_type="CURRENT"
+                pose_type="CURRENT",
             )
 
             # Verify export succeeded
@@ -650,7 +650,7 @@ class TestVPDExporter(unittest.TestCase):
             exporter.export(
                 armature=armature,
                 filepath=output_path,
-                pose_type="INVALID_TYPE"  # This should raise ValueError
+                pose_type="INVALID_TYPE",  # This should raise ValueError
             )
 
 

--- a/tests/test_vpd_exporter.py
+++ b/tests/test_vpd_exporter.py
@@ -7,8 +7,8 @@ import shutil
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core.model import Model
-from bl_ext.user_default.mmd_tools.core.vpd.exporter import VPDExporter
+from bl_ext.blender_org.mmd_tools.core.model import Model
+from bl_ext.blender_org.mmd_tools.core.vpd.exporter import VPDExporter
 from mathutils import Quaternion, Vector
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -69,7 +69,7 @@ class TestVPDExporter(unittest.TestCase):
                 else bpy.ops.preferences.addon_enable
             )
             addon_enable(
-                module="bl_ext.user_default.mmd_tools",
+                module="bl_ext.blender_org.mmd_tools",
             )  # make sure addon 'mmd_tools' is enabled
 
     def __create_model_from_pmx(self, pmx_file):

--- a/tests/test_vpd_importer.py
+++ b/tests/test_vpd_importer.py
@@ -1,3 +1,6 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
 import logging
 import os
 import shutil

--- a/tests/test_vpd_importer.py
+++ b/tests/test_vpd_importer.py
@@ -8,8 +8,8 @@ import traceback
 import unittest
 
 import bpy
-from bl_ext.user_default.mmd_tools.core.model import Model
-from bl_ext.user_default.mmd_tools.core.vpd.importer import VPDImporter
+from bl_ext.blender_org.mmd_tools.core.model import Model
+from bl_ext.blender_org.mmd_tools.core.vpd.importer import VPDImporter
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 SAMPLES_DIR = os.path.join(os.path.dirname(TESTS_DIR), "samples")
@@ -68,7 +68,7 @@ class TestVPDImporter(unittest.TestCase):
                 else bpy.ops.preferences.addon_enable
             )
             addon_enable(
-                module="bl_ext.user_default.mmd_tools",
+                module="bl_ext.blender_org.mmd_tools",
             )  # make sure addon 'mmd_tools' is enabled
 
     def __create_model_from_pmx(self, pmx_file):

--- a/tests/test_vpd_importer.py
+++ b/tests/test_vpd_importer.py
@@ -31,7 +31,7 @@ class TestVPDImporter(unittest.TestCase):
                 shutil.rmtree(item_fp)
 
     def setUp(self):
-        """We should start each test with a clean state"""
+        """Set up testing environment"""
         logger = logging.getLogger()
         logger.setLevel("ERROR")
 

--- a/tests/test_vpd_importer.py
+++ b/tests/test_vpd_importer.py
@@ -54,9 +54,7 @@ class TestVPDImporter(unittest.TestCase):
 
         ret = []
         for root, dirs, files in os.walk(directory):
-            for name in files:
-                if name.lower().endswith("." + extension.lower()):
-                    ret.append(os.path.join(root, name))
+            ret.extend(os.path.join(root, name) for name in files if name.lower().endswith("." + extension.lower()))
         return ret
 
     def __enable_mmd_tools(self):

--- a/tests/test_vpd_importer.py
+++ b/tests/test_vpd_importer.py
@@ -70,7 +70,7 @@ class TestVPDImporter(unittest.TestCase):
                 else bpy.ops.preferences.addon_enable
             )
             addon_enable(
-                module="bl_ext.user_default.mmd_tools"
+                module="bl_ext.user_default.mmd_tools",
             )  # make sure addon 'mmd_tools' is enabled
 
     def __create_model_from_pmx(self, pmx_file):
@@ -132,7 +132,7 @@ class TestVPDImporter(unittest.TestCase):
 
                 if not model_root:
                     print(
-                        "   * Skipping model - no MMD root object found after import"
+                        "   * Skipping model - no MMD root object found after import",
                     )
                     continue
 
@@ -160,7 +160,7 @@ class TestVPDImporter(unittest.TestCase):
 
                         # Import using operator
                         result = bpy.ops.mmd_tools.import_vpd(
-                            filepath=vpd_file, scale=1.0
+                            filepath=vpd_file, scale=1.0,
                         )
 
                         # Check result
@@ -180,7 +180,7 @@ class TestVPDImporter(unittest.TestCase):
                         print(f"   * Exception during VPD import: {str(e)}")
                         print(traceback.format_exc())
                         self.fail(
-                            f"Exception importing VPD {vpd_name} to model {model_name}: {str(e)}"
+                            f"Exception importing VPD {vpd_name} to model {model_name}: {str(e)}",
                         )
 
             except Exception as e:


### PR DESCRIPTION
* **Ruff Compliance**: Fixed numerous lint warnings across 30+ files. Categories include import structure, condition simplifications, unnecessary sets, outdated syntax, and formatting (e.g., `PLR1711`, `UP010`, `COM812`, etc.).
* **Morph Tool Enhancement**: Added a UI button to convert bone morphs into standard vertex shapekeys.
* **Performance Improvements**:

  * Replaced `list()` with `tuple()` where immutability is preferred.
  * Introduced `__slots__` to reduce memory footprint.
  * Switched between modifier and manual normal averaging logic with comments for stability tracking.
* **Readability & Cleanup**:

  * Simplified variable names and comments.
  * Removed outdated Blender 2.8 `FIXME`.
  * Improved string formatting and subprocess calls.
* **Testing Update**: Adjusted test scripts to support new frame margin logic.
* **Issue Resolution**: Addressed multiple issues:
  - #239
  - #240
  - #241
  - #242