### PR TITLE
Add CSV Import/Export to Global Translation Popup

### DIFF
--- a/mmd_tools/operators/translations.py
+++ b/mmd_tools/operators/translations.py
@@ -349,7 +349,6 @@ class GlobalTranslationPopup(bpy.types.Operator):
         translation_box.label(text="Dictionaries:", icon="HELP")
         row = translation_box.row()
         row.prop(mmd_translation, "dictionary", text="to_english")
-        # row.operator(ExecuteTranslationScriptOperator.bl_idname, text='Write to .csv')
 
         translation_box.separator()
         row = translation_box.row()
@@ -359,7 +358,6 @@ class GlobalTranslationPopup(bpy.types.Operator):
         box.separator()
         translation_box = box.box().column(align=True)
         translation_box.label(text="CSV:", icon="FILE_TEXT")
-
         row = translation_box.row()
         row.operator(ImportTranslationCSVOperator.bl_idname, text="Import CSV")
         row.operator(ExportTranslationCSVOperator.bl_idname, text="Export CSV")


### PR DESCRIPTION
This PR adds CSV import and export to Global Translation Popup.

With this feature, you can export current list of names to CSV, paste to whatever AI (ChatGPT, Gemini), get translated list and import back as CSV.

It has checkbox called `Only Update English Name` (the checkbox is in import dialog). This is to prevent renaming Japanese names, which breaks motions.

<img width="963" height="850" alt="Screenshot_2025-07-20_at_1 19 54" src="https://github.com/user-attachments/assets/0f9b9293-cea2-4931-87d2-5ed3c3886cf7" />
