### PR TITLE
Add CSV Import/Export to Global Translation Popup for v3

### DIFF
--- a/mmd_tools/operators/translations.py
+++ b/mmd_tools/operators/translations.py
@@ -426,11 +426,9 @@ class ImportTranslationCSVOperator(bpy.types.Operator):
                     for i in mmd_translation.filtered_translation_element_indices
                 ]
                 translation_elements_list = list(mmd_translation.translation_elements)
-                row_count = 0
 
-                for row in reader:
+                for row_count, row in enumerate(reader):
                     if row_count >= len(visible_indices):
-                        row_count += 1
                         continue
 
                     element = translation_elements_list[visible_indices[row_count]]
@@ -458,16 +456,14 @@ class ImportTranslationCSVOperator(bpy.types.Operator):
                     if updated:
                         updated_count += 1
 
-                    row_count += 1
-
                 # Output warnings
-                if row_count > len(visible_indices):
+                if row_count+1 > len(visible_indices):
                     warnings.append(
-                        f'{row_count - len(visible_indices)} extra lines in CSV! (ignored)'
+                        f'{(row_count+1) - len(visible_indices)} extra lines in CSV! (ignored)'
                     )
-                elif row_count < len(visible_indices):
+                elif row_count+1 < len(visible_indices):
                     warnings.append(
-                        f'{len(visible_indices) - row_count} missing lines in CSV! (aborted translation)'
+                        f'{len(visible_indices) - (row_count+1)} missing lines in CSV! (aborted translation)'
                     )
         except Exception as e:
             self.report({'ERROR'}, f'Failed to read CSV: {e}')


### PR DESCRIPTION
This PR adds CSV Import/Export feature from https://github.com/MMD-Blender/blender_mmd_tools/pull/247 for blender-v3.
Sometimes, MMD Tools in 4.x cannot read bones correctly, so it will not fill the lists in Global Translation Popup, as mentioned in https://github.com/MMD-Blender/blender_mmd_tools/issues/254. So, I figured it would be great to have same feature for older Blender.