### PR TITLE
avoid import/export of invalid display frames, skip empty meshes on export, improve texture export handling, fix "Fix Bone Order" operator idempotency, and add "Fix Bone Order" option to PMX import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MMD ToolsはMMD(MikuMikuDance)のモデルデータ(.pmd, .pmx)、モーショ�
 ## Version Compatibility
 | Blender Version | MMD Tools Version | Branch      |
 |-----------------|-------------------|-------------|
-| Blender 4.2 LTS | MMD Tools v4.x    | [main](https://github.com/MMD-Blender/blender_mmd_tools) |
+| Blender 4.5 LTS | MMD Tools v4.x    | [main](https://github.com/MMD-Blender/blender_mmd_tools) |
 | Blender 3.6 LTS | MMD Tools v2.x    | [blender-v3](https://github.com/MMD-Blender/blender_mmd_tools/tree/blender-v3) |
 
 Use the MMD Tools version that matches your Blender LTS version.

--- a/mmd_tools/core/material.py
+++ b/mmd_tools/core/material.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Iterable, Optional, Tuple, cast
 
 import bpy
@@ -172,7 +173,7 @@ class FnMaterial:
         if mmd_mat.is_shared_toon_texture:
             shared_toon_folder = FnContext.get_addon_preferences_attribute(FnContext.ensure_context(), "shared_toon_folder", "")
             toon_path = os.path.join(shared_toon_folder, "toon%02d.bmp" % (mmd_mat.shared_toon_texture + 1))
-            self.create_toon_texture(bpy.path.resolve_ncase(path=toon_path))
+            self.create_toon_texture(str(Path(toon_path).resolve()))
         elif mmd_mat.toon_texture != "":
             self.create_toon_texture(mmd_mat.toon_texture)
         else:

--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -435,7 +435,7 @@ class FnModel:
 
     @staticmethod
     def realign_bone_ids(bone_id_offset: int, bone_morphs, pose_bones, sorting_method: str = "FIX-MOVE-CHILDREN"):
-        """Realigns all bone IDs sequentially without gaps for bones displayed in Bone Order Panel."""
+        """Realigns all bone IDs sequentially without gaps and sorts bones in MMD-compatible hierarchy order."""
 
         def get_hierarchy_depth(bone):
             """Get the depth of bone in the hierarchy (root bones have depth 0)"""

--- a/mmd_tools/core/pmx/__init__.py
+++ b/mmd_tools/core/pmx/__init__.py
@@ -785,10 +785,14 @@ class Texture:
             self.path = os.path.normpath(os.path.join(os.path.dirname(fs.path()), self.path))
 
     def save(self, fs):
-        try:
-            relPath = os.path.relpath(self.path, os.path.dirname(fs.path()))
-        except ValueError:
+        if not os.path.isabs(self.path):
             relPath = self.path
+        else:
+            try:
+                relPath = os.path.relpath(self.path, os.path.dirname(fs.path()))
+            except ValueError:
+                relPath = self.path
+
         relPath = relPath.replace(os.path.sep, "\\")  # always save using windows path conventions
         logging.info("writing to pmx file the relative texture path: %s", relPath)
         fs.writeStr(relPath)

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -1340,6 +1340,11 @@ class __PmxExporter:
         return _Mesh(material_faces, shape_key_names, material_names)
 
     def __loadMeshData(self, meshObj, bone_map):
+        # Check if mesh has valid geometry
+        if not meshObj.data or len(meshObj.data.vertices) == 0:
+            logging.warning("Skipping empty mesh: %s", meshObj.name)
+            return _Mesh({}, [], {})
+
         show_only_shape_key = meshObj.show_only_shape_key
         active_shape_key_index = meshObj.active_shape_key_index
         meshObj.active_shape_key_index = 0

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -817,13 +817,18 @@ class __PmxExporter:
         morph_map = {}
         index = 0
 
-        # Priority: Display Panel order
+        # Build set of actually existing morphs to filter against
+        existing_morphs = set()
+        existing_morphs.update((self.MORPH_TYPES[type(m)], m.name) for m in self.__model.morphs)
+
+        # Priority: Display Panel order (only for existing morphs)
         facial_frame = self.__get_facial_frame(root)
         if facial_frame:
             for item in facial_frame.data:
                 if item.type == "MORPH":
                     key = (item.morph_type, item.name)
-                    if key not in morph_map:
+                    # Only add if morph actually exists and not already mapped
+                    if key not in morph_map and key in existing_morphs:
                         morph_map[key] = index
                         index += 1
 

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -230,93 +230,69 @@ class __PmxExporter:
             logging.warning("  The texture file does not exist: %s", t.path)
         return len(self.__model.textures) - 1
 
-    def __copy_textures(self, output_dir, base_folder=""):
+    def __copy_textures(self, output_dir, base_folder="", copy_textures=False):
+        # Step 0: Store original paths for Step 2
+        original_paths = {texture: texture.path for texture in self.__model.textures}
+
+        # Step 1: Set PMX texture relative paths
         tex_dir_fallback = os.path.join(output_dir, "textures")
         tex_dir_preference = FnContext.get_addon_preferences_attribute(FnContext.ensure_context(), "base_texture_folder", "")
 
-        path_set = set()  # to prevent overwriting
-        tex_copy_list = []
-
         for texture in self.__model.textures:
-            path = texture.path
-            tex_dir = output_dir  # restart to the default directory at each loop
+            current_path = original_paths[texture]
 
-            # First, look for packed texture (highest priority)
-            packed_image = None
-            filename = os.path.basename(path)
-
-            for image in bpy.data.images:
-                if image.packed_file and (image.filepath == path or os.path.basename(image.filepath) == filename):
-                    packed_image = image
-                    break
-
-            if packed_image:
-                # Use packed texture
-                dst_name = os.path.basename(path)
-                tex_dir = output_dir
-
-                if base_folder:
-                    dst_name = saferelpath(path, base_folder, strategy="outside")
-                    if dst_name.startswith(".."):
-                        # Check if the texture comes from the preferred folder
-                        if tex_dir_preference:
-                            dst_name = saferelpath(path, tex_dir_preference, strategy="outside")
-                        if dst_name.startswith(".."):
-                            # If the texture is still outside, fall back to the basename
-                            logging.warning("The texture %s is not inside the base texture folder", path)
-                            dst_name = os.path.basename(path)
-                            tex_dir = tex_dir_fallback
-                else:
-                    tex_dir = tex_dir_fallback
-
-                dest_path = os.path.join(tex_dir, dst_name)
-                os.makedirs(os.path.dirname(dest_path), exist_ok=True)
-                with open(dest_path, "wb") as f:
-                    f.write(packed_image.packed_file.data)
-
-                logging.info("Extracted packed texture: %s --> %s", packed_image.name, dest_path)
-                texture.path = dest_path
-                path_set.add(os.path.normcase(dest_path))
-                continue
-
-            # Fallback to original file if no packed version
-            if not os.path.isfile(path):
-                logging.warning("*** Texture not found (neither packed nor as an external file), skipping: %s", path)
-                path_set.add(os.path.normcase(path))
-                continue
-
-            dst_name = os.path.basename(path)
+            # Calculate the ideal destination filename and directory based on preference
+            dst_name = os.path.basename(current_path)
+            tex_dir = output_dir  # Restart to the default directory at each loop
             if base_folder:
-                dst_name = saferelpath(path, base_folder, strategy="outside")
+                dst_name = saferelpath(current_path, base_folder, strategy="outside")
                 if dst_name.startswith(".."):
-                    # Check if the texture comes from the preferred folder
                     if tex_dir_preference:
-                        dst_name = saferelpath(path, tex_dir_preference, strategy="outside")
+                        dst_name = saferelpath(current_path, tex_dir_preference, strategy="outside")
                     if dst_name.startswith(".."):
-                        # If the code reaches here the texture is somewhere else
-                        logging.warning("The texture %s is not inside the base texture folder", path)
-                        # Fall back to basename and textures folder
-                        dst_name = os.path.basename(path)
+                        logging.warning("The texture %s is not inside the base texture folder", current_path)
+                        dst_name = os.path.basename(current_path)
                         tex_dir = tex_dir_fallback
             else:
                 tex_dir = tex_dir_fallback
-            dest_path = os.path.join(tex_dir, dst_name)
-            if os.path.normcase(path) != os.path.normcase(dest_path):  # Only copy if the paths are different
-                tex_copy_list.append((texture, path, dest_path))
-            else:
-                path_set.add(os.path.normcase(path))
 
-        for texture, path, dest_path in tex_copy_list:
-            counter = 1
-            base, ext = os.path.splitext(dest_path)
-            while os.path.normcase(dest_path) in path_set:
-                dest_path = "%s_%d%s" % (base, counter, ext)
-                counter += 1
-            path_set.add(os.path.normcase(dest_path))
-            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
-            shutil.copy2(path, dest_path)
-            logging.info("Copy file %s --> %s", path, dest_path)
-            texture.path = dest_path
+            # Determine the full destination path and the final PMX relative path
+            full_dest_path = os.path.join(tex_dir, dst_name)
+            final_relative_path = os.path.relpath(full_dest_path, start=output_dir).replace("\\", "/")
+
+            texture.path = final_relative_path
+
+        # Step 2: Copy textures
+        if copy_textures:
+            for texture in self.__model.textures:
+                src_path = original_paths[texture]
+                dest_relative_path = texture.path
+
+                # Reconstruct the absolute destination path from the PMX's new relative path
+                full_dest_path = os.path.abspath(os.path.join(output_dir, dest_relative_path))
+
+                os.makedirs(os.path.dirname(full_dest_path), exist_ok=True)
+
+                # Check if the source is a packed image
+                packed_image = None
+                for image in bpy.data.images:
+                    if image.packed_file and (image.filepath == src_path or os.path.basename(image.filepath) == os.path.basename(src_path)):
+                        packed_image = image
+                        break
+
+                # Handle packed images first by extracting them
+                if packed_image:
+                    logging.info("Extracting packed texture '%s' -> '%s'", packed_image.name, full_dest_path)
+                    with open(full_dest_path, "wb") as f:
+                        f.write(packed_image.packed_file.data)
+
+                # If not packed, handle existing external files by copying them
+                elif os.path.isfile(src_path):
+                    if os.path.normcase(src_path) != os.path.normcase(full_dest_path):
+                        logging.info("Copying external texture '%s' -> '%s'", src_path, full_dest_path)
+                        shutil.copy2(src_path, full_dest_path)
+                else:
+                    logging.warning("Source for texture '%s' not found. Cannot copy.", src_path)
 
     def __exportMaterial(self, material, num_faces):
         p_mat = pmx.Material()
@@ -1491,11 +1467,11 @@ class __PmxExporter:
         rigid_map = self.__exportRigidBodies(rigids, nameMap)
         self.__exportJoints(joints, rigid_map)
 
-        if args.get("copy_textures", False):
-            output_dir = os.path.dirname(filepath)
-            import_folder = root.get("import_folder", "") if root else ""
-            base_folder = FnContext.get_addon_preferences_attribute(FnContext.ensure_context(), "base_texture_folder", "")
-            self.__copy_textures(output_dir, import_folder or base_folder)
+        output_dir = os.path.dirname(filepath)
+        import_folder = root.get("import_folder", "") if root else ""
+        base_folder = FnContext.get_addon_preferences_attribute(FnContext.ensure_context(), "base_texture_folder", "")
+        copy_textures_enabled = args.get("copy_textures", False)
+        self.__copy_textures(output_dir, import_folder or base_folder, copy_textures=copy_textures_enabled)
 
         # Output Changes in Vertex and Face Count
         original_vertex_count = 0

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -1424,6 +1424,7 @@ class __PmxExporter:
         rigids = sorted(args.get("rigid_bodies", []), key=lambda x: x.name)
         joints = sorted(args.get("joints", []), key=lambda x: x.name)
 
+        bpy.ops.mmd_tools.clean_invalid_bone_id_references()
         if args.get("fix_bone_order", True):
             bpy.ops.mmd_tools.fix_bone_order()
 

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -924,6 +924,8 @@ class __PmxExporter:
     @staticmethod
     def __convertFaceUVToVertexUV(vert_index, uv, normal, vertices_map):
         vertices = vertices_map[vert_index]
+        assert vertices, f"Empty vertices list for vertex index {vert_index}"
+
         for i in vertices:
             if i.uv is None:
                 i.uv = uv
@@ -943,6 +945,8 @@ class __PmxExporter:
             return self.__convertFaceUVToVertexUV(vert_index, uv, normal, vertices_map)
 
         vertices = vertices_map[vert_index]
+        assert vertices, f"Empty vertices list for vertex index {vert_index}"
+
         v = None
         for i in vertices:
             if i.uv is None:

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -1424,7 +1424,8 @@ class __PmxExporter:
         rigids = sorted(args.get("rigid_bodies", []), key=lambda x: x.name)
         joints = sorted(args.get("joints", []), key=lambda x: x.name)
 
-        bpy.ops.mmd_tools.fix_bone_order()
+        if args.get("fix_bone_order", True):
+            bpy.ops.mmd_tools.fix_bone_order()
 
         self.__scale = args.get("scale", 1.0)
         self.__disable_specular = args.get("disable_specular", False)

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -808,17 +808,26 @@ class PMXImporter:
             frame.name_e = i.name_e
             frame.is_special = i.isSpecial
             for disp_type, index in i.data:
-                item = frame.data.add()
                 if disp_type == 0:
-                    item.type = "BONE"
-                    item.name = self.__boneTable[index].name
+                    # Check bone index bounds
+                    if 0 <= index < len(self.__boneTable):
+                        item = frame.data.add()
+                        item.type = "BONE"
+                        item.name = self.__boneTable[index].name
+                    else:
+                        logging.warning("Invalid bone index %d in display frame '%s', skipping item", index, i.name)
                 elif disp_type == 1:
-                    item.type = "MORPH"
-                    morph = pmxModel.morphs[index]
-                    item.name = morph.name
-                    item.morph_type = morph_types[morph.type_index()]
+                    # Check morph index bounds
+                    if 0 <= index < len(pmxModel.morphs):
+                        item = frame.data.add()
+                        item.type = "MORPH"
+                        morph = pmxModel.morphs[index]
+                        item.name = morph.name
+                        item.morph_type = morph_types[morph.type_index()]
+                    else:
+                        logging.warning("Invalid morph index %d in display frame '%s', skipping item", index, i.name)
                 else:
-                    raise Exception("Unknown display item type.")
+                    logging.warning("Unknown display item type %d in display frame '%s', skipping item", disp_type, i.name)
 
         FnBone.sync_bone_collections_from_display_item_frames(self.__armObj)
 

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -6,6 +6,7 @@ import logging
 import math
 import os
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
 import bpy
@@ -187,7 +188,7 @@ class PMXImporter:
 
         self.__textureTable = []
         for i in pmxModel.textures:
-            self.__textureTable.append(bpy.path.resolve_ncase(path=i.path))
+            self.__textureTable.append(str(Path(i.path).resolve()))
 
     def __createEditBones(self, obj, pmx_bones):
         """Create EditBones from pmx file data.

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -929,6 +929,8 @@ class PMXImporter:
                 self.__createMeshObject()
                 self.__importVertexGroup()
             self.__importBones()
+            if args.get("fix_bone_order", True):
+                bpy.ops.mmd_tools.fix_bone_order()
             if args.get("rename_LR_bones", False):
                 use_underscore = args.get("use_underscore", False)
                 self.__renameLRBones(use_underscore)

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -256,6 +256,11 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
         description="Import ADD UV2 data as vertex colors. When enabled, the UV2 layer will still be created.",
         default=False,
     )
+    fix_bone_order: bpy.props.BoolProperty(
+        name="Fix Bone Order",
+        description="Automatically fix bone order after import. This ensures bones are ordered correctly for MMD compatibility.",
+        default=True,
+    )
     fix_ik_links: bpy.props.BoolProperty(
         name="Fix IK Links",
         description="Fix IK links to be blender suitable",
@@ -357,6 +362,7 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
                 clean_model=self.clean_model,
                 remove_doubles=self.remove_doubles,
                 import_adduv2_as_vertex_colors=self.import_adduv2_as_vertex_colors,
+                fix_bone_order=self.fix_bone_order,
                 fix_ik_links=self.fix_ik_links,
                 ik_loop_factor=self.ik_loop_factor,
                 apply_bone_fixed_axis=self.apply_bone_fixed_axis,

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -693,6 +693,11 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
         description="Export visible meshes only",
         default=False,
     )
+    export_vertex_colors_as_adduv2: bpy.props.BoolProperty(
+        name="Export Vertex Colors",
+        description="Export vertex colors as ADD UV2 data. This allows vertex color data to be preserved in the PMX file format. When enabled, existing ADD UV2 data on the model will be skipped during export.",
+        default=False,
+    )
     overwrite_bone_morphs_from_action_pose: bpy.props.BoolProperty(
         name="Overwrite Bone Morphs",
         description="Overwrite the bone morphs from active Action Pose before exporting.",
@@ -744,11 +749,6 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
             ("CUSTOM", "Custom", 'Use custom vertex weight of vertex group "mmd_vertex_order"', 2),
         ],
         default="NONE",
-    )
-    export_vertex_colors_as_adduv2: bpy.props.BoolProperty(
-        name="Export Vertex Colors",
-        description="Export vertex colors as ADD UV2 data. This allows vertex color data to be preserved in the PMX file format. When enabled, existing ADD UV2 data on the model will be skipped during export.",
-        default=False,
     )
     ik_angle_limits: bpy.props.EnumProperty(
         name="IK Angle Limits",
@@ -869,10 +869,10 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
                 sort_materials=self.sort_materials,
                 sort_vertices=self.sort_vertices,
                 disable_specular=self.disable_specular,
+                export_vertex_colors_as_adduv2=self.export_vertex_colors_as_adduv2,
                 vertex_splitting=self.vertex_splitting,
                 keep_sharp=self.keep_sharp,
                 sharp_edge_angle=self.sharp_edge_angle,
-                export_vertex_colors_as_adduv2=self.export_vertex_colors_as_adduv2,
                 ik_angle_limits=self.ik_angle_limits,
             )
             self.report({"INFO"}, f'Exported MMD model "{root.name}" to "{self.filepath}"')

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -351,6 +351,7 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
         if self.save_log:
             handler = log_handler(self.log_level, filepath=self.filepath + ".mmd_tools.import.log")
             logger.addHandler(handler)
+
         try:
             importer_cls = pmx_importer.PMXImporter
             if re.search(r"\.pmd$", self.filepath, flags=re.IGNORECASE):

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -698,6 +698,11 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
         description="Export vertex colors as ADD UV2 data. This allows vertex color data to be preserved in the PMX file format. When enabled, existing ADD UV2 data on the model will be skipped during export.",
         default=False,
     )
+    fix_bone_order: bpy.props.BoolProperty(
+        name="Fix Bone Order",
+        description="Automatically fix bone order before export. This ensures bones are ordered correctly for MMD compatibility.",
+        default=True,
+    )
     overwrite_bone_morphs_from_action_pose: bpy.props.BoolProperty(
         name="Overwrite Bone Morphs",
         description="Overwrite the bone morphs from active Action Pose before exporting.",
@@ -864,6 +869,7 @@ class ExportPmx(Operator, ExportHelper, PreferencesMixin):
                 rigid_bodies=FnModel.iterate_rigid_body_objects(root),
                 joints=FnModel.iterate_joint_objects(root),
                 copy_textures=self.copy_textures,
+                fix_bone_order=self.fix_bone_order,
                 overwrite_bone_morphs_from_action_pose=self.overwrite_bone_morphs_from_action_pose,
                 translate_in_presets=self.translate_in_presets,
                 sort_materials=self.sort_materials,

--- a/mmd_tools/panels/sidebar/bone_order.py
+++ b/mmd_tools/panels/sidebar/bone_order.py
@@ -47,10 +47,6 @@ class MMDToolsBoneIdMoveUp(bpy.types.Operator):
             # safe swap bone IDs
             FnModel.swap_bone_ids(active_bone, prev_bone, root.mmd_root.bone_morphs, armature.pose.bones)
 
-            # Refresh UI
-            for area in context.screen.areas:
-                area.tag_redraw()
-
         return {"FINISHED"}
 
 
@@ -93,10 +89,6 @@ class MMDToolsBoneIdMoveDown(bpy.types.Operator):
             # safe swap bone IDs
             FnModel.swap_bone_ids(active_bone, next_bone, root.mmd_root.bone_morphs, armature.pose.bones)
 
-            # Refresh UI
-            for area in context.screen.areas:
-                area.tag_redraw()
-
         return {"FINISHED"}
 
 
@@ -124,10 +116,6 @@ class MMDToolsBoneIdMoveTop(bpy.types.Operator):
         pose_bones = armature.pose.bones
         FnModel.shift_bone_id(old_bone_id, new_bone_id, bone_morphs, pose_bones)
 
-        # Refresh UI
-        for area in context.screen.areas:
-            area.tag_redraw()
-
         return {"FINISHED"}
 
 
@@ -154,10 +142,6 @@ class MMDToolsBoneIdMoveBottom(bpy.types.Operator):
         bone_morphs = root.mmd_root.bone_morphs
         pose_bones = armature.pose.bones
         FnModel.shift_bone_id(old_bone_id, new_bone_id, bone_morphs, pose_bones)
-
-        # Refresh UI
-        for area in context.screen.areas:
-            area.tag_redraw()
 
         return {"FINISHED"}
 
@@ -201,10 +185,6 @@ class MMDToolsRealignBoneIds(bpy.types.Operator):
         # Apply additional transformation (Assembly -> Bone button) (Very Slow)
         MigrationFnBone.fix_mmd_ik_limit_override(armature)
         FnBone.apply_additional_transformation(armature)
-
-        # Refresh UI
-        for area in context.screen.areas:
-            area.tag_redraw()
 
         return {"FINISHED"}
 

--- a/mmd_tools/typings/mmd_tools/properties/pose_bone.pyi
+++ b/mmd_tools/typings/mmd_tools/properties/pose_bone.pyi
@@ -25,4 +25,4 @@ class MMDBone:
     is_additional_transform_dirty: bool
     display_connection_bone: str
     display_connection_bone_id: int
-    display_connection_type: str  # 'BONE', 'OFFSET'
+    display_connection_type: str  # "BONE", "OFFSET"


### PR DESCRIPTION
This PR fixes issues:
* #236
* #259
* #260
* #263

Other improvements included:
* Added bounds checking for display frame items during PMX import
* Skipped empty meshes during PMX export to prevent Blender crashes
* Added defensive asserts for empty vertices list validation
* Fix "Fix Bone Order" operator idempotency
* Add "Fix Bone Order" option to PMX import/export