### PR TITLE
Add Value slider below the morph list

### DIFF
--- a/mmd_tools/panels/sidebar/morph_tools.py
+++ b/mmd_tools/panels/sidebar/morph_tools.py
@@ -50,6 +50,10 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
 
         morph = ItemOp.get_by_index(getattr(mmd_root, morph_type), mmd_root.active_morph)
         if morph:
+            slider = rig.morph_slider.get(morph.name)
+            if slider:
+                col.row().prop(slider, "value")
+
             row = col.row(align=True)
             row.prop(
                 mmd_root,


### PR DESCRIPTION
I added original Value slider back, because in Blender, `Shape Keys` menu have sliders both in shape key list and below the list.
This was suggested by @rintrint 
<img width="421" height="550" alt="Screenshot_2025-08-28_at_19 16 35" src="https://github.com/user-attachments/assets/7aa66861-3614-4069-bae1-0664858cd800" />
<img width="691" height="738" alt="Snipaste_2025-08-28_19-03-52" src="https://github.com/user-attachments/assets/a9355a28-8198-4a76-b518-4b7c485f2c54" />
