### PR TITLE
Bone Display Mode dropdown in import dialog

### DIFF
--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -903,6 +903,7 @@ class PMXImporter:
         self.__spa_blend_factor = args.get("spa_blend_factor", 1.0)
         self.__fix_ik_links = args.get("fix_ik_links", False)
         self.__apply_bone_fixed_axis = args.get("apply_bone_fixed_axis", False)
+        self.__bone_disp_mode = args.get("bone_disp_mode", "OCTAHEDRAL")
         self.__translator = args.get("translator")
 
         logging.info("****************************************")
@@ -944,6 +945,7 @@ class PMXImporter:
                 self.__translateBoneNames()
             if self.__apply_bone_fixed_axis:
                 FnBone.apply_bone_fixed_axis(self.__armObj)
+            self.__armObj.data.display_type = self.__bone_disp_mode
             FnBone.apply_additional_transformation(self.__armObj)
 
         if "PHYSICS" in types:

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -187,6 +187,13 @@ def load_default_settings_from_preferences(operator, context, preset_property_na
         return False
 
 
+def get_armature_display_items(self, context):
+    # https://docs.blender.org/api/current/bpy.props.html#bpy.props.EnumProperty
+    # self & context are required, even though they are not used in function
+    enum_items = bpy.types.Armature.bl_rna.properties["display_type"].enum_items
+    return [(item.identifier, item.name, "") for item in enum_items]
+
+
 class PreferencesMixin:
     """Mixin for operators that load default settings from preferences"""
 
@@ -289,6 +296,11 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
         description="Will not use dot, e.g. if renaming bones, will use _R instead of .R",
         default=False,
     )
+    bone_disp_mode: bpy.props.EnumProperty(
+        name="Bone Display Mode",
+        items=get_armature_display_items,
+        description="Change how bones look in viewport.",
+    )
     dictionary: bpy.props.EnumProperty(
         name="Rename Bones To English",
         items=DictionaryEnum.get_dictionary_items,
@@ -370,6 +382,7 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
                 apply_bone_fixed_axis=self.apply_bone_fixed_axis,
                 rename_LR_bones=self.rename_bones,
                 use_underscore=self.use_underscore,
+                bone_disp_mode=self.bone_disp_mode,
                 translator=self.__translator,
                 use_mipmap=self.use_mipmap,
                 sph_blend_factor=self.sph_blend_factor,

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -296,15 +296,15 @@ class ImportPmx(Operator, ImportHelper, PreferencesMixin):
         description="Will not use dot, e.g. if renaming bones, will use _R instead of .R",
         default=False,
     )
-    bone_disp_mode: bpy.props.EnumProperty(
-        name="Bone Display Mode",
-        items=get_armature_display_items,
-        description="Change how bones look in viewport.",
-    )
     dictionary: bpy.props.EnumProperty(
         name="Rename Bones To English",
         items=DictionaryEnum.get_dictionary_items,
         description="Translate bone names from Japanese to English using selected dictionary",
+    )
+    bone_disp_mode: bpy.props.EnumProperty(
+        name="Bone Display Mode",
+        items=get_armature_display_items,
+        description="Change how bones look in viewport.",
     )
     use_mipmap: bpy.props.BoolProperty(
         name="use MIP maps for UV textures",


### PR DESCRIPTION
This PR adds dropdown in import dialog to change display mode of Armature when importing.
This allows imported models to use preferred mode without changing them after importing.
<img width="321" height="406" alt="Screenshot 2025-09-03 at 3 43 30" src="https://github.com/user-attachments/assets/4600c6c7-b17f-4d4b-ae03-d4115078ea19" />
