### PR TITLE
Fix animation state reset when creating new actions

### DIFF
--- a/locales/ja_JP.po
+++ b/locales/ja_JP.po
@@ -1441,7 +1441,7 @@ msgid ""
 "- Select the armature: imports only armature animation"
 msgstr ""
 
-#. :src: bpy.types.MMD_TOOLS_OT_import_vmd.always_create_new_action
+#. :src: bpy.types.MMD_TOOLS_OT_import_vmd.create_new_action
 msgid "Create a new action when importing VMD, otherwise add keyframes to existing actions if available. Note: This option is ignored when 'Use NLA' is enabled."
 msgstr ""
 

--- a/locales/zh_HANS.po
+++ b/locales/zh_HANS.po
@@ -1434,7 +1434,7 @@ msgid ""
 "- Select the armature: imports only armature animation"
 msgstr ""
 
-#. :src: bpy.types.MMD_TOOLS_OT_import_vmd.always_create_new_action
+#. :src: bpy.types.MMD_TOOLS_OT_import_vmd.create_new_action
 msgid "Create a new action when importing VMD, otherwise add keyframes to existing actions if available. Note: This option is ignored when 'Use NLA' is enabled."
 msgstr ""
 

--- a/mmd_tools/auto_scene_setup.py
+++ b/mmd_tools/auto_scene_setup.py
@@ -10,7 +10,7 @@ def setupFrameRanges():
     e = base
 
     for action in bpy.data.actions:
-        # When always_create_new_action=False, multiple VMDs share the same action
+        # When create_new_action=False, multiple VMDs share the same action
         # Need to toggle use_frame_range to access frame ranges from both VMDs:
         # use_frame_range = True: gets range from the first imported VMD
         # use_frame_range = False: gets range from the newly imported VMD

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -303,7 +303,7 @@ class HasAnimationData:
 
 
 class VMDImporter:
-    def __init__(self, filepath, scale=1.0, bone_mapper=None, use_pose_mode=False, convert_mmd_camera=True, convert_mmd_lamp=True, frame_margin=5, use_mirror=False, always_create_new_action=False, use_nla=False, detect_camera_changes=True, detect_lamp_changes=True):
+    def __init__(self, filepath, scale=1.0, bone_mapper=None, use_pose_mode=False, convert_mmd_camera=True, convert_mmd_lamp=True, frame_margin=5, use_mirror=False, create_new_action=False, use_nla=False, detect_camera_changes=True, detect_lamp_changes=True):
         self.__vmdFile = vmd.File()
         self.__vmdFile.load(filepath=filepath)
         logging.debug(str(self.__vmdFile.header))
@@ -315,7 +315,7 @@ class VMDImporter:
         self.__frame_start = bpy.context.scene.frame_current
         self.__frame_margin = frame_margin if self.__frame_start in {0, 1} else 0  # only applies if current frame is 0 or 1
         self.__mirror = use_mirror
-        self.__always_create_new_action = always_create_new_action
+        self.__create_new_action = create_new_action
         self.__use_nla = use_nla
         self.__detect_camera_changes = detect_camera_changes
         self.__detect_lamp_changes = detect_lamp_changes
@@ -423,7 +423,7 @@ class VMDImporter:
             target.animation_data_create()
 
         if not self.__use_nla:
-            if not self.__always_create_new_action and target.animation_data.action:
+            if not self.__create_new_action and target.animation_data.action:
                 return target.animation_data.action
             target.animation_data.action = action
         else:
@@ -443,7 +443,7 @@ class VMDImporter:
         else:
             animation_data = getattr(target, "animation_data", None)
 
-        if not self.__always_create_new_action and animation_data and animation_data.action:
+        if not self.__create_new_action and animation_data and animation_data.action:
             return animation_data.action
 
         return bpy.data.actions.new(name=action_name)

--- a/mmd_tools/core/vmd/importer.py
+++ b/mmd_tools/core/vmd/importer.py
@@ -10,6 +10,7 @@ import bpy
 from mathutils import Quaternion, Vector
 
 from ... import utils
+from ...core.model import FnModel
 from .. import vmd
 from ..camera import MMDCamera
 from ..lamp import MMDLamp
@@ -807,11 +808,82 @@ class VMDImporter:
         self.__assign_action(lampObj.data, color_action)
         self.__assign_action(lampObj, location_action)
 
+    def __reset_all_animations(self, target_obj):
+        """Reset all animation states for the target object and related MMD model objects"""
+        root_object = FnModel.find_root_object(target_obj)
+        objects_to_process = set()
+
+        if root_object:
+            objects_to_process.add(root_object)
+            objects_to_process.add(target_obj)
+            # Add armature object
+            armature_object = FnModel.find_armature_object(root_object)
+            if armature_object:
+                objects_to_process.add(armature_object)
+            # Add all mesh objects
+            objects_to_process.update(FnModel.iterate_mesh_objects(root_object))
+            # Add other group objects if they exist
+            rigid_group = FnModel.find_rigid_group_object(root_object)
+            if rigid_group:
+                objects_to_process.add(rigid_group)
+            joint_group = FnModel.find_joint_group_object(root_object)
+            if joint_group:
+                objects_to_process.add(joint_group)
+            temporary_group = FnModel.find_temporary_group_object(root_object)
+            if temporary_group:
+                objects_to_process.add(temporary_group)
+        else:
+            objects_to_process.add(target_obj)
+
+        # STEP 1: Clear all existing actions first
+        for obj in objects_to_process:
+            # Clear object's own actions
+            if obj.animation_data:
+                obj.animation_data.action = None
+
+            # Clear Shape Keys actions
+            if hasattr(obj, "data") and hasattr(obj.data, "shape_keys") and obj.data.shape_keys:
+                if obj.data.shape_keys.animation_data:
+                    obj.data.shape_keys.animation_data.action = None
+
+            # Clear light data actions
+            if obj.type == "LIGHT" and obj.data.animation_data:
+                obj.data.animation_data.action = None
+
+        # STEP 2: Reset all properties to default states
+        for obj in objects_to_process:
+            if obj.type == "ARMATURE":
+                # Reset armature pose
+                for bone in obj.pose.bones:
+                    bone.location = (0.0, 0.0, 0.0)
+                    bone.rotation_quaternion = (1.0, 0.0, 0.0, 0.0)
+                    bone.rotation_euler = (0.0, 0.0, 0.0)
+                    bone.rotation_axis_angle = (0.0, 0.0, 1.0, 0.0)
+                    bone.scale = (1.0, 1.0, 1.0)
+
+                    # Reset IK settings to default
+                    if hasattr(bone, "mmd_ik_toggle"):
+                        bone.mmd_ik_toggle = True
+
+            elif obj.type == "MESH" and getattr(obj.data, "shape_keys", None):
+                # Reset mesh morphs
+                for shape_key in obj.data.shape_keys.key_blocks:
+                    if shape_key.name != "Basis":  # Don't reset basis shape key
+                        shape_key.value = 0.0
+
+            elif hasattr(obj, "mmd_type") and obj.mmd_type == "ROOT":
+                # Reset root display state
+                if hasattr(obj, "mmd_root") and hasattr(obj.mmd_root, "show_meshes"):
+                    obj.mmd_root.show_meshes = True  # Default to show meshes
+
     def assign(self, obj, action_name=None):
         if obj is None:
             return
         if action_name is None:
             action_name = os.path.splitext(os.path.basename(self.__vmdFile.filepath))[0]
+
+        if self.__create_new_action:
+            self.__reset_all_animations(obj)
 
         if MMDCamera.isMMDCamera(obj):
             self.__assignToCamera(obj, action_name + "_camera")

--- a/mmd_tools/m17n.py
+++ b/mmd_tools/m17n.py
@@ -2454,7 +2454,7 @@ translations_tuple = (
             "*",
             "Create a new action when importing VMD, otherwise add keyframes to existing actions if available. Note: This option is ignored when 'Use NLA' is enabled.",
         ),
-        (("bpy.types.MMD_TOOLS_OT_import_vmd.always_create_new_action",), ()),
+        (("bpy.types.MMD_TOOLS_OT_import_vmd.create_new_action",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "", (False, ())),
     ),

--- a/mmd_tools/operators/fileio.py
+++ b/mmd_tools/operators/fileio.py
@@ -463,7 +463,7 @@ class ImportVmd(Operator, ImportHelper, PreferencesMixin):
         description="Update frame range and frame rate (30 fps)",
         default=True,
     )
-    always_create_new_action: bpy.props.BoolProperty(
+    create_new_action: bpy.props.BoolProperty(
         name="Create New Action",
         description="Create a new action when importing VMD, otherwise add keyframes to existing actions if available. Note: This option is ignored when 'Use NLA' is enabled.",
         default=False,
@@ -518,7 +518,7 @@ class ImportVmd(Operator, ImportHelper, PreferencesMixin):
         layout = self.layout
         layout.prop(self, "scale")
         layout.prop(self, "margin")
-        layout.prop(self, "always_create_new_action")
+        layout.prop(self, "create_new_action")
         layout.prop(self, "use_nla")
 
         layout.prop(self, "bone_mapper")
@@ -577,7 +577,7 @@ class ImportVmd(Operator, ImportHelper, PreferencesMixin):
                     use_pose_mode=self.use_pose_mode,
                     frame_margin=self.margin,
                     use_mirror=self.use_mirror,
-                    always_create_new_action=self.always_create_new_action,
+                    create_new_action=self.create_new_action,
                     use_nla=self.use_nla,
                     detect_camera_changes=self.detect_camera_changes,
                     detect_lamp_changes=self.detect_lamp_changes,

--- a/tests/test_vmd_exporter.py
+++ b/tests/test_vmd_exporter.py
@@ -462,7 +462,7 @@ class TestVmdExporter(unittest.TestCase):
                     mesh_obj.select_set(True)
 
                 # Import VMD motion
-                bpy.ops.mmd_tools.import_vmd(files=[{"name": os.path.basename(vmd_file)}], directory=os.path.dirname(vmd_file), scale=0.08, margin=0, bone_mapper="PMX", use_pose_mode=False, use_mirror=False, update_scene_settings=True, always_create_new_action=True, use_nla=False)
+                bpy.ops.mmd_tools.import_vmd(files=[{"name": os.path.basename(vmd_file)}], directory=os.path.dirname(vmd_file), scale=0.08, margin=0, bone_mapper="PMX", use_pose_mode=False, use_mirror=False, update_scene_settings=True, create_new_action=True, use_nla=False)
                 print("    VMD imported successfully")
 
                 # Export VMD motion

--- a/tests/test_vmd_importer.py
+++ b/tests/test_vmd_importer.py
@@ -989,14 +989,14 @@ class TestVMDImporter(unittest.TestCase):
                 print("NLA tracks were not created (this may be normal depending on the MMD Tools version)")
 
     def test_vmd_import_new_action_settings(self):
-        """Test VMD importing with always_create_new_action option"""
+        """Test VMD importing with create_new_action option"""
         vmd_files = self._list_sample_files("vmd", "vmd")
         if not vmd_files:
             self.fail("No VMD sample files found for new action test")
 
         armature = self._create_standard_mmd_armature()
 
-        importer1 = VMDImporter(filepath=vmd_files[0], always_create_new_action=False)
+        importer1 = VMDImporter(filepath=vmd_files[0], create_new_action=False)
         importer1.assign(armature)
 
         first_action = None
@@ -1004,13 +1004,13 @@ class TestVMDImporter(unittest.TestCase):
             first_action = armature.animation_data.action
             self.assertIsNotNone(first_action, "First action should be created")
 
-        importer2 = VMDImporter(filepath=vmd_files[0], always_create_new_action=True)
+        importer2 = VMDImporter(filepath=vmd_files[0], create_new_action=True)
         importer2.assign(armature)
 
         if armature.animation_data and first_action:
             second_action = armature.animation_data.action
             self.assertIsNotNone(second_action, "Second action should be created")
-            self.assertNotEqual(first_action, second_action, "Should create a new action when always_create_new_action=True")
+            self.assertNotEqual(first_action, second_action, "Should create a new action when create_new_action=True")
 
     def test_vmd_import_detect_changes(self):
         """Test VMD importing with detect_camera_changes and detect_lamp_changes options"""


### PR DESCRIPTION
Fix animation state reset when creating new actions
Add comprehensive animation state reset functionality to prevent residual
animation data when importing VMD files with create_new_action enabled.

- Add __reset_all_animations() method to clear existing actions and reset properties
- Clear all animation data from objects, shape keys, and light data
- Reset bone transforms, morph values, and root display state to defaults
- Process all MMD model objects including armature, meshes, and group objects

Fixes issue where old animation states would persist and interfere with
newly imported VMD data.