### PR TITLE
Add Display Frame unlocker

### DIFF
--- a/mmd_tools/m17n.py
+++ b/mmd_tools/m17n.py
@@ -1063,7 +1063,7 @@ translations_tuple = (
         ("Operator", "Unlock Display Item Frame"),
         (("bpy.types.MMD_TOOLS_OT_display_item_frame_unlock",), ()),
         ("ja_JP", "表示枠をアンロック", (False, ())),
-        ("zh_HANS", "移动显示项目帧", (True, ())),
+        ("zh_HANS", "解锁表示枠", (False, ())),
     ),
     (
         ("*", "Remove active display item frame from the list"),
@@ -1075,25 +1075,25 @@ translations_tuple = (
         ("*", "Unlock display item frame to change its name"),
         (("bpy.types.MMD_TOOLS_OT_display_item_frame_unlock", "bpy.types.MMD_TOOLS_OT_display_item_frame_unlock.type:'UNLOCK'"), ()),
         ("ja_JP", "表示項目フレームをアンロックして名称を変更する", (False, ())),
-        ("zh_HANS", "", (False, ())),
+        ("zh_HANS", "解锁显示项目帧以编辑名称", (False, ())),
     ),
     (
         ("*", "Unlock Display Frame"),
         (("bpy.types.MMD_TOOLS_OT_display_item_frame_unlock.type:'UNLOCK'",), ()),
         ("ja_JP", "表示枠をアンロック", (False, ())),
-        ("zh_HANS", "", (False, ())),
+        ("zh_HANS", "解锁表示枠", (False, ())),
     ),
     (
         ("*", "Lock Display Frame"),
         (("bpy.types.MMD_TOOLS_OT_display_item_frame_unlock.type:'LOCK'",), ()),
         ("ja_JP", "表示枠をロック", (False, ())),
-        ("zh_HANS", "", (False, ())),
+        ("zh_HANS", "锁定表示枠", (False, ())),
     ),
     (
         ("*", "Lock display item frame"),
         (("bpy.types.MMD_TOOLS_OT_display_item_frame_unlock.type:'LOCK'",), ()),
         ("ja_JP", "表示項目フレームをロック", (False, ())),
-        ("zh_HANS", "", (False, ())),
+        ("zh_HANS", "锁定显示项目帧", (False, ())),
     ),
     (
         ("Operator", "Move Display Item"),

--- a/mmd_tools/operators/display_item.py
+++ b/mmd_tools/operators/display_item.py
@@ -87,11 +87,21 @@ class UnlockDisplayItemFrame(Operator):
         default="UNLOCK",
     )
 
+    index: bpy.props.IntProperty(
+        name="Index",
+        description="Index of the frame to unlock",
+        default=-1,
+        options={"SKIP_SAVE", "HIDDEN"},
+    )
+
     def execute(self, context):
         obj = context.active_object
         root = FnModel.find_root_object(obj)
         mmd_root = root.mmd_root
-        frame = ItemOp.get_by_index(mmd_root.display_item_frames, mmd_root.active_display_item_frame)
+
+        target_index = self.index if self.index >= 0 else mmd_root.active_display_item_frame
+        frame = ItemOp.get_by_index(mmd_root.display_item_frames, target_index)
+
         if frame is None:
             return {"CANCELLED"}
         if self.type == "UNLOCK":

--- a/mmd_tools/panels/sidebar/display_panel.py
+++ b/mmd_tools/panels/sidebar/display_panel.py
@@ -83,10 +83,18 @@ class MMD_ROOT_UL_display_item_frames(bpy.types.UIList):
                 row.label(text=frame.name, translate=False)
                 row = row.row(align=True)
                 row.label(text=frame.name_e, translate=False)
-                row.label(text="", icon="LOCKED")
+
+                op = row.operator("mmd_tools.display_item_frame_unlock", text="", icon="LOCKED", emboss=False)
+                op.type = "UNLOCK"
+                op.index = _index
             else:
                 row.prop(frame, "name", text="", emboss=False)
+                row = row.row(align=True)
                 row.prop(frame, "name_e", text="", emboss=True)
+
+                op = row.operator("mmd_tools.display_item_frame_unlock", text="", icon="UNLOCKED", emboss=False)
+                op.type = "LOCK"
+                op.index = _index
         elif self.layout_type == "COMPACT":
             pass
         elif self.layout_type == "GRID":
@@ -171,8 +179,6 @@ class MMDDisplayItemFrameMenu(bpy.types.Menu):
     def draw(self, context):
         layout = self.layout
         layout.operator_enum("mmd_tools.display_item_quick_setup", "type")
-        layout.separator()
-        layout.operator_enum("mmd_tools.display_item_frame_unlock", "type")
         layout.separator()
         layout.operator("mmd_tools.display_item_frame_move", icon="TRIA_UP_BAR", text="Move To Top").type = "TOP"
         layout.operator("mmd_tools.display_item_frame_move", icon="TRIA_DOWN_BAR", text="Move To Bottom").type = "BOTTOM"


### PR DESCRIPTION
This is a way to solve this:

<img width="472" height="485" alt="unlock" src="https://github.com/user-attachments/assets/9bdc698b-ee3d-4b97-b5d5-19317af638ee" />

`Expresíon facial` has to be renamed to `表情`, but since those frames are special (locked), you cannot change their name. with this unlocker, you can bypass this and edit their name, and lock them later.
