### PR TITLE
Add bl_info to get rid of warning in console when plugin is loaded at launch

### DIFF
--- a/mmd_tools/__init__.py
+++ b/mmd_tools/__init__.py
@@ -14,6 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+bl_info = {
+    "name": "MMD Tools",
+    "author": "MMD",
+    "version": (4, 5, 13),
+    "blender": (5, 2, 0),
+    "description": "Utility tools for MMD model editing",
+}
+
 import os
 
 from . import auto_load


### PR DESCRIPTION
I was getting a warning regarding the missing `bl_info` from `__init__.py` when loading up with console. When I looked at other working plugins from other authors they generally all had this in there.

I've included in the PR with a set version of Blender 5.2 and version 4.5.13 (current release). Feel free to change these to whichever values or details that match the next release.

Thanks!